### PR TITLE
judges-action#539: add mising decoor for TapedHash

### DIFF
--- a/lib/factbase/taped.rb
+++ b/lib/factbase/taped.rb
@@ -3,6 +3,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2024-2025 Yegor Bugayenko
 # SPDX-License-Identifier: MIT
 
+require 'decoor'
 require_relative '../factbase'
 
 # A decorator of an Array with HashMaps, that records facts that have been touched,
@@ -82,6 +83,8 @@ class Factbase::Taped
 
   # Decorator of Hash.
   class TapedHash
+    decoor(:origin)
+
     def initialize(origin, added)
       @origin = origin
       @added = added

--- a/test/test_factbase.rb
+++ b/test/test_factbase.rb
@@ -485,4 +485,16 @@ class TestFactbase < Factbase::Test
     end
     assert_equal(1, fb.size)
   end
+
+  def test_get_raise_for_empty_fact
+    fb = Factbase.new
+    fb.txn do |fbt|
+      f = fbt.insert
+      f.foo = 123
+      f = fbt.query('(always)').each.to_a.first
+      assert_equal(123, f.foo)
+      ex = assert_raises(RuntimeError) { f.bar }
+      assert_equal("Can't find 'bar' attribute out of [foo]", ex.message)
+    end
+  end
 end


### PR DESCRIPTION
Need for https://github.com/zerocracy/judges-action/issues/539
Fix this error:
```ruby
3.3.4 :004 > require 'factbase'
 => true 
3.3.4 :005 > 
3.3.4 :006 > fb = Factbase.new
3.3.4 :007 > fb.txn do |fbt|
3.3.4 :008 >   f = fbt.insert
3.3.4 :009 >   f.prop123 = 123
3.3.4 :010 >   f = fbt.query('(always)').each.to_a.first
3.3.4 :011 >   puts f.prop123
3.3.4 :012 >   puts f.prop111
3.3.4 :013 > end
123
/home/artem/.rvm/gems/ruby-3.3.4/gems/factbase-0.10.0/lib/factbase/fact.rb:69:in `block in <class:Fact>': undefined method `empty?' for an instance of Factbase::Taped::TapedHash (NoMethodError)

        raise "Can't get '#{k}', the fact is empty" if @map.empty?
                                                           ^^^^^^^
        from /home/artem/.rvm/gems/ruby-3.3.4/gems/others-0.0.3/lib/others.rb:38:in `instance_exec'
        from /home/artem/.rvm/gems/ruby-3.3.4/gems/others-0.0.3/lib/others.rb:38:in `method_missing'
        from /home/artem/.rvm/gems/ruby-3.3.4/gems/factbase-0.10.0/lib/factbase/tee.rb:41:in `public_send'
        from /home/artem/.rvm/gems/ruby-3.3.4/gems/factbase-0.10.0/lib/factbase/tee.rb:41:in `block in <class:Tee>'
        from /home/artem/.rvm/gems/ruby-3.3.4/gems/others-0.0.3/lib/others.rb:38:in `instance_exec'
        from /home/artem/.rvm/gems/ruby-3.3.4/gems/others-0.0.3/lib/others.rb:38:in `method_missing'
        from /home/artem/.rvm/gems/ruby-3.3.4/gems/factbase-0.10.0/lib/factbase/accum.rb:49:in `public_send'
        from /home/artem/.rvm/gems/ruby-3.3.4/gems/factbase-0.10.0/lib/factbase/accum.rb:49:in `block in <class:Accum>'
        from /home/artem/.rvm/gems/ruby-3.3.4/gems/others-0.0.3/lib/others.rb:38:in `instance_exec'
        from /home/artem/.rvm/gems/ruby-3.3.4/gems/others-0.0.3/lib/others.rb:38:in `method_missing'
        from (irb):12:in `block in <top (required)>'
        from /home/artem/.rvm/gems/ruby-3.3.4/gems/factbase-0.10.0/lib/factbase.rb:181:in `block in txn'
        from /home/artem/.rvm/gems/ruby-3.3.4/gems/factbase-0.10.0/lib/factbase.rb:179:in `catch'
        from /home/artem/.rvm/gems/ruby-3.3.4/gems/factbase-0.10.0/lib/factbase.rb:179:in `txn'
        from (irb):7:in `<main>'
        from <internal:kernel>:187:in `loop'
        ... 5 levels...
```