### PR TITLE
#321: fix lock mutex in `Factbase::SyncFactbase` and `Factbase::SyncQuery`

### DIFF
--- a/lib/factbase/sync/sync_query.rb
+++ b/lib/factbase/sync/sync_query.rb
@@ -13,10 +13,10 @@ require_relative '../../factbase'
 class Factbase::SyncQuery
   # Constructor.
   # @param [Factbase::Query] origin Original query
-  # @param [Mutex] mutex The mutex
-  def initialize(origin, mutex, fb)
+  # @param [Monitor] monitor The monitor
+  def initialize(origin, monitor, fb)
     @origin = origin
-    @mutex = mutex
+    @monitor = monitor
     @fb = fb
   end
 
@@ -58,10 +58,6 @@ class Factbase::SyncQuery
   private
 
   def try_lock(&)
-    if @mutex.owned?
-      yield
-    else
-      @mutex.synchronize(&)
-    end
+    @monitor.synchronize(&)
   end
 end

--- a/test/factbase/sync/test_sync_factbase.rb
+++ b/test/factbase/sync/test_sync_factbase.rb
@@ -68,7 +68,11 @@ class TestSyncFactbase < Factbase::Test
         end
       end
     end
-    assert_equal(t + 1, fb.query('(exists foo)').each.to_a.size)
+    assert_equal(
+      t + 1, fb.query('(exists foo)').each.to_a.size,
+      'Number of facts with the foo property, must be equal to the number of threads that insert a new fact ' \
+      'with the foo property + one modifying fact with baz property'
+    )
     assert_equal(t, fb.query('(exists bar)').each.to_a.size)
     fb.query('(exists baz)').each.to_a.then do |fs|
       assert_equal(1, fs.size)


### PR DESCRIPTION
[`try_lock` method](https://docs.ruby-lang.org/en/3.4/Thread/Mutex.html#method-i-try_lock) tried to take a lock and returned the result of attempt, what is not true.
More see in https://github.com/yegor256/factbase/issues/321#issuecomment-3374279620