### PR TITLE
feat(#302): move 'assert' and 'traced' terms out of 'term' module

### DIFF
--- a/lib/factbase/term.rb
+++ b/lib/factbase/term.rb
@@ -12,6 +12,8 @@ require_relative 'terms/prev'
 require_relative 'terms/concat'
 require_relative 'terms/sprintf'
 require_relative 'terms/matches'
+require_relative 'terms/traced'
+require_relative 'terms/assert'
 
 # Term.
 #
@@ -76,9 +78,6 @@ class Factbase::Term
   require_relative 'terms/system'
   include Factbase::System
 
-  require_relative 'terms/debug'
-  include Factbase::Debug
-
   require_relative 'terms/shared'
   include Factbase::TermShared
 
@@ -93,7 +92,9 @@ class Factbase::Term
       prev: Factbase::Prev.new(operands),
       concat: Factbase::Concat.new(operands),
       sprintf: Factbase::Sprintf.new(operands),
-      matches: Factbase::Matches.new(operands)
+      matches: Factbase::Matches.new(operands),
+      traced: Factbase::Traced.new(operands),
+      assert: Factbase::Assert.new(operands)
     }
   end
 
@@ -180,27 +181,6 @@ class Factbase::Term
       return true if o.is_a?(Symbol) && o.to_s.start_with?('$')
     end
     false
-  end
-
-  # Turns it into a string.
-  # @return [String] The string of it
-  def to_s
-    @to_s ||=
-      begin
-        items = []
-        items << @op
-        items +=
-          @operands.map do |o|
-            if o.is_a?(String)
-              "'#{o.gsub("'", "\\\\'").gsub('"', '\\\\"')}'"
-            elsif o.is_a?(Time)
-              o.utc.iso8601
-            else
-              o.to_s
-            end
-          end
-        "(#{items.join(' ')})"
-      end
   end
 
   def at(fact, maps, fb)

--- a/lib/factbase/terms/assert.rb
+++ b/lib/factbase/terms/assert.rb
@@ -3,24 +3,26 @@
 # SPDX-FileCopyrightText: Copyright (c) 2024-2025 Yegor Bugayenko
 # SPDX-License-Identifier: MIT
 
-require_relative '../../factbase'
+require_relative 'base'
 
-# Debug terms.
-#
-# Author:: Yegor Bugayenko (yegor256@gmail.com)
-# Copyright:: Copyright (c) 2024-2025 Yegor Bugayenko
-# License:: MIT
-module Factbase::Debug
-  def traced(fact, maps, fb)
-    assert_args(1)
-    t = @operands[0]
-    raise "A term is expected, but '#{t}' provided" unless t.is_a?(Factbase::Term)
-    r = t.evaluate(fact, maps, fb)
-    puts "#{self} -> #{r}"
-    r
+# The `Factbase::Assert` class represents an assertion term in the Factbase system.
+# It verifies that a given condition evaluates to true, raising an error with
+# a specified message if the assertion fails.
+class Factbase::Assert < Factbase::TermBase
+  # Constructor.
+  # @param [Array] operands Operands
+  def initialize(operands)
+    super()
+    @operands = operands
+    @op = 'assert'
   end
 
-  def assert(fact, maps, fb)
+  # Evaluate term on a fact.
+  # @param [Factbase::Fact] fact The fact
+  # @param [Array<Factbase::Fact>] maps All maps available
+  # @param [Factbase] fb Factbase to use for sub-queries
+  # @return [Boolean] Returns true if the assertion passes, otherwise raises an error with the provided message
+  def evaluate(fact, maps, fb)
     assert_args(2)
     message = @operands[0]
     unless message.is_a?(String)

--- a/lib/factbase/terms/base.rb
+++ b/lib/factbase/terms/base.rb
@@ -13,5 +13,5 @@ class Factbase::TermBase
   require_relative 'shared'
   include Factbase::TermShared
 
-  protected :assert_args, :_by_symbol, :_values
+  protected :assert_args, :_by_symbol, :_values, :to_s
 end

--- a/lib/factbase/terms/shared.rb
+++ b/lib/factbase/terms/shared.rb
@@ -9,6 +9,27 @@
 #  Currently, we use it because we are required to inject all thesse methods into Factbase::Term.
 #  When all the terms will inherit from Factbase::TermBase, we can remove this module.
 module Factbase::TermShared
+  # Turns it into a string.
+  # @return [String] The string of it
+  def to_s
+    @to_s ||=
+      begin
+        items = []
+        items << @op
+        items +=
+          @operands.map do |o|
+            if o.is_a?(String)
+              "'#{o.gsub("'", "\\\\'").gsub('"', '\\\\"')}'"
+            elsif o.is_a?(Time)
+              o.utc.iso8601
+            else
+              o.to_s
+            end
+          end
+        "(#{items.join(' ')})"
+      end
+  end
+
   private
 
   def assert_args(num)

--- a/lib/factbase/terms/traced.rb
+++ b/lib/factbase/terms/traced.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2025 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+require_relative 'base'
+
+# A class representing a traced term in the factbase.
+# This class is responsible for evaluating a term and printing
+# its evaluation result for tracing purposes.
+class Factbase::Traced < Factbase::TermBase
+  # Constructor.
+  # @param [Array] operands Operands
+  def initialize(operands)
+    super()
+    @operands = operands
+    @op = 'traced'
+  end
+
+  # Evaluate term on a fact.
+  # @param [Factbase::Fact] fact The fact
+  # @param [Array<Factbase::Fact>] maps All maps available
+  # @param [Factbase] fb Factbase to use for sub-queries
+  # @return [Object] Return value of the traced term
+  def evaluate(fact, maps, fb)
+    assert_args(1)
+    t = @operands[0]
+    raise "A term is expected, but '#{t}' provided" unless t.is_a?(Factbase::Term)
+    r = t.evaluate(fact, maps, fb)
+    puts "#{self} -> #{r}"
+    r
+  end
+end

--- a/test/factbase/terms/test_assert.rb
+++ b/test/factbase/terms/test_assert.rb
@@ -5,42 +5,20 @@
 
 require_relative '../../test__helper'
 require_relative '../../../lib/factbase/term'
+require_relative '../../../lib/factbase/terms/assert'
 
-# Debug test.
-# Author:: Yegor Bugayenko (yegor256@gmail.com)
+# Test for assert term.
+# Author:: Volodya Lombrozo (volodya.lombrozo@gmail.com)
 # Copyright:: Copyright (c) 2024-2025 Yegor Bugayenko
 # License:: MIT
-class TestDebug < Factbase::Test
-  def test_traced
-    t = Factbase::Term.new(:traced, [Factbase::Term.new(:defn, [:test_debug, 'self.to_s'])])
-    assert_output("(traced (defn test_debug 'self.to_s')) -> true\n") do
-      assert(t.evaluate(fact, [], Factbase.new))
-    end
-  end
-
-  def test_traced_raises
-    e = assert_raises(StandardError) { Factbase::Term.new(:traced, ['foo']).evaluate(fact, [], Factbase.new) }
-    assert_match(/A term is expected, but 'foo' provided/, e.message)
-  end
-
-  def test_traced_raises_when_too_many_args
-    e =
-      assert_raises(StandardError) do
-        Factbase::Term.new(
-          :traced,
-          [Factbase::Term.new(:defn, [:debug, 'self.to_s']), 'something']
-        ).evaluate(fact, [], Factbase.new)
-      end
-    assert_match(/Too many \(\d+\) operands for 'traced' \(\d+ expected\)/, e.message)
-  end
-
+class TestAssert < Factbase::Test
   def test_assert_with_true_condition
-    t = Factbase::Term.new(:assert, ['all must be positive', Factbase::Term.new(:gt, [:foo, 0])])
+    t = Factbase::Assert.new(['all must be positive', Factbase::Term.new(:gt, [:foo, 0])])
     assert(t.evaluate(fact('foo' => 5), [], Factbase.new))
   end
 
   def test_assert_with_false_condition
-    t = Factbase::Term.new(:assert, ['all must be positive', Factbase::Term.new(:gt, [:foo, 0])])
+    t = Factbase::Assert.new(['all must be positive', Factbase::Term.new(:gt, [:foo, 0])])
     e =
       assert_raises(RuntimeError) do
         t.evaluate(fact('foo' => -1), [], Factbase.new)
@@ -49,7 +27,7 @@ class TestDebug < Factbase::Test
   end
 
   def test_assert_with_zero_value
-    t = Factbase::Term.new(:assert, ['value must not be zero', Factbase::Term.new(:gt, [:foo, 0])])
+    t = Factbase::Assert.new(['value must not be zero', Factbase::Term.new(:gt, [:foo, 0])])
     e =
       assert_raises(RuntimeError) do
         t.evaluate(fact('foo' => 0), [], Factbase.new)
@@ -58,12 +36,12 @@ class TestDebug < Factbase::Test
   end
 
   def test_assert_with_array_true_condition
-    t = Factbase::Term.new(:assert, ['at least one positive', Factbase::Term.new(:gt, [:foo, 0])])
+    t = Factbase::Assert.new(['at least one positive', Factbase::Term.new(:gt, [:foo, 0])])
     assert(t.evaluate(fact('foo' => [1, 2, 3]), [], Factbase.new))
   end
 
   def test_assert_with_array_false_condition
-    t = Factbase::Term.new(:assert, ['at least one positive', Factbase::Term.new(:gt, [:foo, 0])])
+    t = Factbase::Assert.new(['at least one positive', Factbase::Term.new(:gt, [:foo, 0])])
     e =
       assert_raises(RuntimeError) do
         t.evaluate(fact('foo' => [-1, -2, -3]), [], Factbase.new)
@@ -72,14 +50,14 @@ class TestDebug < Factbase::Test
   end
 
   def test_assert_with_mixed_array
-    t = Factbase::Term.new(:assert, ['at least one positive', Factbase::Term.new(:gt, [:foo, 0])])
+    t = Factbase::Assert.new(['at least one positive', Factbase::Term.new(:gt, [:foo, 0])])
     assert(t.evaluate(fact('foo' => [-1, 0, 3]), [], Factbase.new))
   end
 
   def test_assert_raises_when_message_not_string
     e =
       assert_raises(StandardError) do
-        Factbase::Term.new(:assert, [123, Factbase::Term.new(:gt, [:foo, 0])]).evaluate(fact, [], Factbase.new)
+        Factbase::Assert.new([123, Factbase::Term.new(:gt, [:foo, 0])]).evaluate(fact, [], Factbase.new)
       end
     assert_match(/A string is expected as first argument of 'assert', but '123' provided/, e.message)
   end
@@ -87,7 +65,7 @@ class TestDebug < Factbase::Test
   def test_assert_raises_when_second_arg_not_term
     e =
       assert_raises(StandardError) do
-        Factbase::Term.new(:assert, %w[message not_a_term]).evaluate(fact, [], Factbase.new)
+        Factbase::Assert.new(%w[message not_a_term]).evaluate(fact, [], Factbase.new)
       end
     assert_match(/A term is expected as second argument of 'assert', but 'not_a_term' provided/, e.message)
   end
@@ -95,7 +73,7 @@ class TestDebug < Factbase::Test
   def test_assert_raises_when_too_few_args
     e =
       assert_raises(StandardError) do
-        Factbase::Term.new(:assert, ['message']).evaluate(fact, [], Factbase.new)
+        Factbase::Assert.new(['message']).evaluate(fact, [], Factbase.new)
       end
     assert_match(/Too few \(\d+\) operands for 'assert' \(\d+ expected\)/, e.message)
   end
@@ -103,8 +81,7 @@ class TestDebug < Factbase::Test
   def test_assert_raises_when_too_many_args
     e =
       assert_raises(StandardError) do
-        Factbase::Term.new(:assert, ['message', Factbase::Term.new(:gt, [:foo, 0]), 'extra']).evaluate(fact, [],
-                                                                                                       Factbase.new)
+        Factbase::Assert.new(['message', Factbase::Term.new(:gt, [:foo, 0]), 'extra']).evaluate(fact, [], Factbase.new)
       end
     assert_match(/Too many \(\d+\) operands for 'assert' \(\d+ expected\)/, e.message)
   end

--- a/test/factbase/terms/test_traced.rb
+++ b/test/factbase/terms/test_traced.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2025 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+require_relative '../../test__helper'
+require_relative '../../../lib/factbase/term'
+require_relative '../../../lib/factbase/terms/traced'
+
+# Test for traced term.
+# Author:: Volodya Lombrozo (volodya.lombrozo@gmail.com)
+# Copyright:: Copyright (c) 2024-2025 Yegor Bugayenko
+# License:: MIT
+class TestTraced < Factbase::Test
+  def test_traced
+    t = Factbase::Traced.new([Factbase::Term.new(:defn, [:test_debug, 'self.to_s'])])
+    assert_output("(traced (defn test_debug 'self.to_s')) -> true\n") do
+      assert(t.evaluate(fact, [], Factbase.new))
+    end
+  end
+
+  def test_traced_raises
+    e = assert_raises(StandardError) { Factbase::Traced.new(['foo']).evaluate(fact, [], Factbase.new) }
+    assert_match(/A term is expected, but 'foo' provided/, e.message)
+  end
+
+  def test_traced_raises_when_too_many_args
+    e =
+      assert_raises(StandardError) do
+        Factbase::Traced.new(
+          [Factbase::Term.new(:defn, [:debug, 'self.to_s']), 'something']
+        ).evaluate(fact, [], Factbase.new)
+      end
+    assert_match(/Too many \(\d+\) operands for 'traced' \(\d+ expected\)/, e.message)
+  end
+end


### PR DESCRIPTION
This PR refactors the `Factbase::Term` class by introducing individual classes for `assert` and `traced` terms, enhancing code organization and maintainability.

Related to #302