### PR TITLE
refactor(#302): separate 'defn' and 'undef'  terms into individual classes for cleaner design

### DIFF
--- a/lib/factbase/term.rb
+++ b/lib/factbase/term.rb
@@ -15,6 +15,8 @@ require_relative 'terms/matches'
 require_relative 'terms/traced'
 require_relative 'terms/assert'
 require_relative 'terms/env'
+require_relative 'terms/defn'
+require_relative 'terms/undef'
 
 # Term.
 #
@@ -73,9 +75,6 @@ class Factbase::Term
   require_relative 'terms/aliases'
   include Factbase::Aliases
 
-  require_relative 'terms/defn'
-  include Factbase::Defn
-
   require_relative 'terms/shared'
   include Factbase::TermShared
 
@@ -93,7 +92,9 @@ class Factbase::Term
       matches: Factbase::Matches.new(operands),
       traced: Factbase::Traced.new(operands),
       assert: Factbase::Assert.new(operands),
-      env: Factbase::Env.new(operands)
+      env: Factbase::Env.new(operands),
+      defn: Factbase::Defn.new(operands),
+      undef: Factbase::Undef.new(operands)
     }
   end
 

--- a/lib/factbase/terms/defn.rb
+++ b/lib/factbase/terms/defn.rb
@@ -3,15 +3,26 @@
 # SPDX-FileCopyrightText: Copyright (c) 2024-2025 Yegor Bugayenko
 # SPDX-License-Identifier: MIT
 
-require_relative '../../factbase'
+require_relative 'base'
 
-# Defn terms.
-#
+# Factbase::Defn is responsible for defining new terms in the Factbase system.
 # Author:: Yegor Bugayenko (yegor256@gmail.com)
 # Copyright:: Copyright (c) 2024-2025 Yegor Bugayenko
 # License:: MIT
-module Factbase::Defn
-  def defn(_fact, _maps, _fb)
+class Factbase::Defn < Factbase::TermBase
+  # Constructor.
+  # @param [Array] operands Operands
+  def initialize(operands)
+    super()
+    @operands = operands
+  end
+
+  # Evaluate term on a fact.
+  # @param [Factbase::Fact] fact The fact
+  # @param [Array<Factbase::Fact>] maps All maps available
+  # @param [Factbase] fb Factbase to use for sub-queries
+  # @return [Object] Term definition result
+  def evaluate(_fact, _maps, _fb)
     assert_args(2)
     fn = @operands[0]
     raise "A symbol expected as first argument of 'defn'" unless fn.is_a?(Symbol)
@@ -22,16 +33,6 @@ module Factbase::Defn
     # rubocop:disable Security/Eval
     eval(e)
     # rubocop:enable Security/Eval
-    true
-  end
-
-  def undef(_fact, _maps, _fb)
-    assert_args(1)
-    fn = @operands[0]
-    raise "A symbol expected as first argument of 'undef'" unless fn.is_a?(Symbol)
-    if Factbase::Term.private_instance_methods(false).include?(fn)
-      Factbase::Term.class_eval("undef :#{fn}", __FILE__, __LINE__ - 1) # undef :foo
-    end
     true
   end
 end

--- a/lib/factbase/terms/undef.rb
+++ b/lib/factbase/terms/undef.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2025 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+require_relative 'base'
+# Implements the `undef` term for Factbase, which removes a method from the class.
+# Author:: Yegor Bugayenko (yegor256@gmail.com)
+# Copyright:: Copyright (c) 2024-2025 Yegor Bugayenko
+# License:: MIT
+class Factbase::Undef < Factbase::TermBase
+  # Constructor.
+  # @param [Array] operands Operands
+  def initialize(operands)
+    super()
+    @operands = operands
+  end
+
+  # Evaluate term on a fact.
+  # @param [Factbase::Fact] fact The fact
+  # @param [Array<Factbase::Fact>] maps All maps available
+  # @param [Factbase] fb Factbase to use for sub-queries
+  # @return [Boolean] True if definition is successfully removed.
+  def evaluate(_fact, _maps, _fb)
+    assert_args(1)
+    fn = @operands[0]
+    raise "A symbol expected as first argument of 'undef'" unless fn.is_a?(Symbol)
+    if Factbase::Term.private_instance_methods(false).include?(fn)
+      Factbase::Term.class_eval("undef :#{fn}", __FILE__, __LINE__ - 1) # undef :foo
+    end
+    true
+  end
+end

--- a/test/factbase/terms/test_defn.rb
+++ b/test/factbase/terms/test_defn.rb
@@ -5,44 +5,38 @@
 
 require_relative '../../test__helper'
 require_relative '../../../lib/factbase/term'
+require_relative '../../../lib/factbase/terms/defn'
 
-# Defn test.
+# Test for defn term.
 # Author:: Yegor Bugayenko (yegor256@gmail.com)
 # Copyright:: Copyright (c) 2024-2025 Yegor Bugayenko
 # License:: MIT
 class TestDefn < Factbase::Test
   def test_defn_simple
-    t = Factbase::Term.new(:defn, [:foo, 'self.to_s'])
+    t = Factbase::Defn.new([:foo, 'self.to_s'])
     assert(t.evaluate(fact('foo' => 4), [], Factbase.new))
     t1 = Factbase::Term.new(:foo, ['hello, world!'])
     assert_equal('(foo \'hello, world!\')', t1.evaluate(fact, [], Factbase.new))
   end
 
   def test_defn_again_by_mistake
-    t = Factbase::Term.new(:defn, [:and, 'self.to_s'])
+    t = Factbase::Defn.new([:and, 'self.to_s'])
     assert_raises(StandardError) do
       t.evaluate(fact, [], Factbase.new)
     end
   end
 
   def test_defn_bad_name_by_mistake
-    t = Factbase::Term.new(:defn, [:to_s, 'self.to_s'])
+    t = Factbase::Defn.new([:to_s, 'self.to_s'])
     assert_raises(StandardError) do
       t.evaluate(fact, [], Factbase.new)
     end
   end
 
   def test_defn_bad_name_spelling_by_mistake
-    t = Factbase::Term.new(:defn, [:'some-key', 'self.to_s'])
+    t = Factbase::Defn.new([:'some-key', 'self.to_s'])
     assert_raises(StandardError) do
       t.evaluate(fact, [], Factbase.new)
     end
-  end
-
-  def test_undef_simple
-    t = Factbase::Term.new(:defn, [:hello, 'self.to_s'])
-    assert(t.evaluate(fact, [], Factbase.new))
-    t = Factbase::Term.new(:undef, [:hello])
-    assert(t.evaluate(fact, [], Factbase.new))
   end
 end

--- a/test/factbase/terms/test_undef.rb
+++ b/test/factbase/terms/test_undef.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2025 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+require_relative '../../test__helper'
+require_relative '../../../lib/factbase/term'
+require_relative '../../../lib/factbase/terms/defn'
+require_relative '../../../lib/factbase/terms/undef'
+
+# Test for undef term.
+# Author:: Volodya Lombrozo (volodya.lombrozo@gmail.com)
+# Copyright:: Copyright (c) 2024-2025 Yegor Bugayenko
+# License:: MIT
+class TestUndef < Factbase::Test
+  def test_undef_simple
+    t = Factbase::Defn.new([:hello, 'self.to_s'])
+    assert(t.evaluate(fact, [], Factbase.new))
+    t = Factbase::Undef.new([:hello])
+    assert(t.evaluate(fact, [], Factbase.new))
+  end
+end


### PR DESCRIPTION
This PR refactors the `Factbase::Term` class by creating separate classes for `defn` and `undef` terms, enhancing code organization.

Related to #302