### PR TITLE
feat(#302): create separate classes for 'as' and 'join' terms in Factbase

### DIFF
--- a/lib/factbase/term.rb
+++ b/lib/factbase/term.rb
@@ -17,6 +17,8 @@ require_relative 'terms/assert'
 require_relative 'terms/env'
 require_relative 'terms/defn'
 require_relative 'terms/undef'
+require_relative 'terms/as'
+require_relative 'terms/join'
 
 # Term.
 #
@@ -72,9 +74,6 @@ class Factbase::Term
   require_relative 'terms/meta'
   include Factbase::Meta
 
-  require_relative 'terms/aliases'
-  include Factbase::Aliases
-
   require_relative 'terms/shared'
   include Factbase::TermShared
 
@@ -94,7 +93,9 @@ class Factbase::Term
       assert: Factbase::Assert.new(operands),
       env: Factbase::Env.new(operands),
       defn: Factbase::Defn.new(operands),
-      undef: Factbase::Undef.new(operands)
+      undef: Factbase::Undef.new(operands),
+      as: Factbase::As.new(operands),
+      join: Factbase::Join.new(operands)
     }
   end
 

--- a/lib/factbase/terms/as.rb
+++ b/lib/factbase/terms/as.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2025 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+require_relative 'base'
+#
+# The Factbase::As class is a specialized term that evaluates
+# and assigns values to a specific attribute of a fact.
+class Factbase::As < Factbase::TermBase
+  # Constructor.
+  # @param [Array] operands Operands
+  def initialize(operands)
+    super()
+    @operands = operands
+  end
+
+  # Evaluate term on a fact.
+  # @param [Factbase::Fact] fact The fact
+  # @param [Array<Factbase::Fact>] maps All maps available
+  # @param [Factbase] fb Factbase to use for sub-queries
+  # @return [Boolean] True if succeeded
+  def evaluate(fact, maps, fb)
+    assert_args(2)
+    a = @operands[0]
+    raise "A symbol is expected as first argument of 'as'" unless a.is_a?(Symbol)
+    vv = _values(1, fact, maps, fb)
+    vv&.each { |v| fact.send(:"#{a}=", v) }
+    true
+  end
+end

--- a/lib/factbase/terms/join.rb
+++ b/lib/factbase/terms/join.rb
@@ -3,24 +3,24 @@
 # SPDX-FileCopyrightText: Copyright (c) 2024-2025 Yegor Bugayenko
 # SPDX-License-Identifier: MIT
 
-require_relative '../../factbase'
+require_relative 'base'
 
-# Aliases terms.
-#
-# Author:: Yegor Bugayenko (yegor256@gmail.com)
-# Copyright:: Copyright (c) 2024-2025 Yegor Bugayenko
-# License:: MIT
-module Factbase::Aliases
-  def as(fact, maps, fb)
-    assert_args(2)
-    a = @operands[0]
-    raise "A symbol is expected as first argument of 'as'" unless a.is_a?(Symbol)
-    vv = _values(1, fact, maps, fb)
-    vv&.each { |v| fact.send(:"#{a}=", v) }
-    true
+# The Factbase::Join class is a specialized term that performs
+# join operations between facts based on specified attribute mappings.
+class Factbase::Join < Factbase::TermBase
+  # Constructor.
+  # @param [Array] operands Operands
+  def initialize(operands)
+    super()
+    @operands = operands
   end
 
-  def join(fact, maps, fb)
+  # Evaluate term on a fact.
+  # @param [Factbase::Fact] fact The fact
+  # @param [Array<Factbase::Fact>] maps All maps available
+  # @param [Factbase] fb Factbase to use for sub-queries
+  # @return [Boolean] True if succeeded
+  def evaluate(fact, maps, fb)
     assert_args(2)
     jumps = @operands[0]
     raise "A string is expected as first argument of 'join'" unless jumps.is_a?(String)

--- a/test/factbase/terms/test_as.rb
+++ b/test/factbase/terms/test_as.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2025 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+require_relative '../../test__helper'
+require_relative '../../../lib/factbase/term'
+require_relative '../../../lib/factbase/terms/as'
+require_relative '../../../lib/factbase/syntax'
+require_relative '../../../lib/factbase/accum'
+
+# Test for 'as' term.
+# Author:: Yegor Bugayenko (yegor256@gmail.com)
+# Copyright:: Copyright (c) 2024-2025 Yegor Bugayenko
+# License:: MIT
+class TestAs < Factbase::Test
+  def test_aliases
+    maps = [
+      { 'x' => [1], 'y' => [0], 't1' => [Time.now], 't2' => [Time.now] },
+      { 'x' => [2], 'y' => [42], 't' => [Time.now] }
+    ]
+    {
+      '(as foo (plus x 1))' => '(exists foo)',
+      '(as foo (plus x y))' => '(gt foo 0)',
+      '(as foo (plus bar 1))' => '(absent foo)',
+      '(as foo (minus t1 t2))' => '(when (exists foo) (eq "Float" (type foo)))'
+    }.each do |q, r|
+      t = Factbase::Syntax.new(q).to_term
+      maps.each do |m|
+        f = Factbase::Accum.new(fact(m), {}, false)
+        next unless t.evaluate(f, maps, Factbase.new)
+        assert(Factbase::Syntax.new(r).to_term.evaluate(f, [], Factbase.new), "#{q} -> #{f}")
+      end
+    end
+  end
+end

--- a/test/factbase/terms/test_join.rb
+++ b/test/factbase/terms/test_join.rb
@@ -6,34 +6,15 @@
 require 'loog'
 require_relative '../../test__helper'
 require_relative '../../../lib/factbase/term'
+require_relative '../../../lib/factbase/terms/join'
 require_relative '../../../lib/factbase/syntax'
 require_relative '../../../lib/factbase/accum'
 
-# Aliases test.
+# Test for 'as' term.
 # Author:: Yegor Bugayenko (yegor256@gmail.com)
 # Copyright:: Copyright (c) 2024-2025 Yegor Bugayenko
 # License:: MIT
-class TestAliases < Factbase::Test
-  def test_aliases
-    maps = [
-      { 'x' => [1], 'y' => [0], 't1' => [Time.now], 't2' => [Time.now] },
-      { 'x' => [2], 'y' => [42], 't' => [Time.now] }
-    ]
-    {
-      '(as foo (plus x 1))' => '(exists foo)',
-      '(as foo (plus x y))' => '(gt foo 0)',
-      '(as foo (plus bar 1))' => '(absent foo)',
-      '(as foo (minus t1 t2))' => '(when (exists foo) (eq "Float" (type foo)))'
-    }.each do |q, r|
-      t = Factbase::Syntax.new(q).to_term
-      maps.each do |m|
-        f = Factbase::Accum.new(fact(m), {}, false)
-        next unless t.evaluate(f, maps, Factbase.new)
-        assert(Factbase::Syntax.new(r).to_term.evaluate(f, [], Factbase.new), "#{q} -> #{f}")
-      end
-    end
-  end
-
+class TestJoin < Factbase::Test
   def test_join
     maps = [
       { 'x' => 1, 'y' => 0, 'z' => 4 },


### PR DESCRIPTION
This PR refactors the `Factbase::Term` class by introducing separate classes for `As` and `Join` terms, enhancing code organization.

Related to #302