### PR TITLE
feat(#245): add benchmark for transaction rollback

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -53,7 +53,8 @@ RuboCop::RakeTask.new(:rubocop) do |task|
 end
 
 desc 'Benchmark them all'
-task :benchmark do
+task :benchmark, [:name] do |_t, args|
+  bname = args[:name] || 'all'
   require_relative 'lib/factbase'
   fb = Factbase.new
   require_relative 'lib/factbase/cached/cached_factbase'
@@ -64,7 +65,13 @@ task :benchmark do
   fb = Factbase::SyncFactbase.new(fb)
   require 'benchmark'
   Benchmark.bm(60) do |b|
-    Dir['benchmark/bench_*.rb'].each do |f|
+    if bname == 'all'
+      Dir['benchmark/bench_*.rb'].each do |f|
+        require_relative f
+        Kernel.send(File.basename(f).gsub(/\.rb$/, '').to_sym, b, fb)
+      end
+    else
+      f = "benchmark/#{bname}.rb"
       require_relative f
       Kernel.send(File.basename(f).gsub(/\.rb$/, '').to_sym, b, fb)
     end

--- a/benchmark/bench_lots_facts.rb
+++ b/benchmark/bench_lots_facts.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2025 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+require_relative '../lib/factbase'
+require_relative '../lib/factbase/logged'
+
+def bench_lots_facts(bmk, fb)
+  total = 100_000
+  total.times do |i|
+    f = fb.insert
+    f.id = i
+    f.time = Time.now
+    f.label = %w[bug feature][rand(0..1)]
+    f.rpository = 'factbase' if rand(0..1).zero?
+  end
+  bmk.report("transaction rollback on factbase with #{total} facts") do
+    fb.txn do |fbt|
+      100.times do |i|
+        f = fbt.insert
+        f.id = total + i
+        f.transaction = 'done'
+      end
+      raise Factbase::Rollback
+    end
+    query = fb.query('(agg (exists transaction) (count))')
+    raise "Unexpected result for: #{query}" unless query.one.zero?
+  end
+end


### PR DESCRIPTION
This PR enhances the `:benchmark` task in the `Rakefile` to support specific benchmarks and adds `bench_lots_facts.rb` for testing transaction rollbacks in large factbases.

Related to #245