### PR TITLE
feat(#302): refactor term handling by creating individual term classes for 'exists', 'absent', 'size' and 'type'

### DIFF
--- a/lib/factbase/term.rb
+++ b/lib/factbase/term.rb
@@ -19,6 +19,10 @@ require_relative 'terms/defn'
 require_relative 'terms/undef'
 require_relative 'terms/as'
 require_relative 'terms/join'
+require_relative 'terms/exists'
+require_relative 'terms/absent'
+require_relative 'terms/size'
+require_relative 'terms/type'
 
 # Term.
 #
@@ -95,7 +99,11 @@ class Factbase::Term
       defn: Factbase::Defn.new(operands),
       undef: Factbase::Undef.new(operands),
       as: Factbase::As.new(operands),
-      join: Factbase::Join.new(operands)
+      join: Factbase::Join.new(operands),
+      exists: Factbase::Exists.new(operands),
+      absent: Factbase::Absent.new(operands),
+      size: Factbase::Size.new(operands),
+      type: Factbase::Type.new(operands)
     }
   end
 

--- a/lib/factbase/terms/absent.rb
+++ b/lib/factbase/terms/absent.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2025 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+require_relative 'base'
+
+# Represents a term that evaluates to true if the specified operand is absent in the fact.
+class Factbase::Absent < Factbase::TermBase
+  # Constructor.
+  # @param [Array] operands Operands
+  def initialize(operands)
+    super()
+    @operands = operands
+  end
+
+  # Evaluate term on a fact.
+  # @param [Factbase::Fact] fact The fact
+  # @param [Array<Factbase::Fact>] maps All maps available
+  # @param [Factbase] fb Factbase to use for sub-queries
+  # @return [Boolean] True if absent
+  def evaluate(fact, _maps, _fb)
+    assert_args(1)
+    _by_symbol(0, fact).nil?
+  end
+end

--- a/lib/factbase/terms/exists.rb
+++ b/lib/factbase/terms/exists.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2025 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+require_relative 'base'
+
+# Represents a term that checks if a certain condition exists within the factbase.
+# This class evaluates whether a specific term exists in the given context of facts.
+class Factbase::Exists < Factbase::TermBase
+  # Constructor.
+  # @param [Array] operands Operands
+  def initialize(operands)
+    super()
+    @operands = operands
+  end
+
+  # Evaluate term on a fact.
+  # @param [Factbase::Fact] fact The fact
+  # @param [Array<Factbase::Fact>] maps All maps available
+  # @param [Factbase] fb Factbase to use for sub-queries
+  # @return [Boolean] True if exists
+  def evaluate(fact, _maps, _fb)
+    assert_args(1)
+    !_by_symbol(0, fact).nil?
+  end
+end

--- a/lib/factbase/terms/meta.rb
+++ b/lib/factbase/terms/meta.rb
@@ -11,32 +11,6 @@ require_relative '../../factbase'
 # Copyright:: Copyright (c) 2024-2025 Yegor Bugayenko
 # License:: MIT
 module Factbase::Meta
-  def exists(fact, _maps, _fb)
-    assert_args(1)
-    !_by_symbol(0, fact).nil?
-  end
-
-  def absent(fact, _maps, _fb)
-    assert_args(1)
-    _by_symbol(0, fact).nil?
-  end
-
-  def size(fact, _maps, _fb)
-    assert_args(1)
-    v = _by_symbol(0, fact)
-    return 0 if v.nil?
-    return 1 unless v.respond_to?(:to_a)
-    v.size
-  end
-
-  def type(fact, _maps, _fb)
-    assert_args(1)
-    v = _by_symbol(0, fact)
-    return 'nil' if v.nil?
-    v = v[0] if v.respond_to?(:each) && v.size == 1
-    v.class.to_s
-  end
-
   def nil(fact, maps, fb)
     assert_args(1)
     _values(0, fact, maps, fb).nil?

--- a/lib/factbase/terms/size.rb
+++ b/lib/factbase/terms/size.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2025 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+require_relative 'base'
+
+# Factbase::Size is a term that calculates the size of an operand
+# when evaluated on a given fact.
+class Factbase::Size < Factbase::TermBase
+  # Constructor.
+  # @param [Array] operands Operands
+  def initialize(operands)
+    super()
+    @operands = operands
+  end
+
+  # Evaluate term on a fact.
+  # @param [Factbase::Fact] fact The fact
+  # @param [Array<Factbase::Fact>] maps All maps available
+  # @param [Factbase] fb Factbase to use for sub-queries
+  # @return [Integer] Size of the operand
+  def evaluate(fact, _maps, _fb)
+    assert_args(1)
+    v = _by_symbol(0, fact)
+    return 0 if v.nil?
+    return 1 unless v.respond_to?(:to_a)
+    v.size
+  end
+end

--- a/lib/factbase/terms/type.rb
+++ b/lib/factbase/terms/type.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2025 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+require_relative 'base'
+
+# Represents a type term in the Factbase.
+# This class evaluates the type of the given operand
+# based on the provided fact, maps, and factbase.
+class Factbase::Type < Factbase::TermBase
+  # Constructor.
+  # @param [Array] operands Operands
+  def initialize(operands)
+    super()
+    @operands = operands
+  end
+
+  # Evaluate term on a fact.
+  # @param [Factbase::Fact] fact The fact
+  # @param [Array<Factbase::Fact>] maps All maps available
+  # @param [Factbase] fb Factbase to use for sub-queries
+  # @return [String] Type of the operand
+  def evaluate(fact, _maps, _fb)
+    assert_args(1)
+    v = _by_symbol(0, fact)
+    return 'nil' if v.nil?
+    v = v[0] if v.respond_to?(:each) && v.size == 1
+    v.class.to_s
+  end
+end

--- a/test/factbase/terms/test_absent.rb
+++ b/test/factbase/terms/test_absent.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2025 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+require_relative '../../test__helper'
+require_relative '../../../lib/factbase/term'
+require_relative '../../../lib/factbase/terms/absent'
+
+# Test for 'absent' term.
+# Author:: Yegor Bugayenko (yegor256@gmail.com)
+# Copyright:: Copyright (c) 2024-2025 Yegor Bugayenko
+# License:: MIT
+class TestAbsent < Factbase::Test
+  def test_absent
+    t = Factbase::Absent.new([:foo])
+    refute(t.evaluate(fact('foo' => 41), [], Factbase.new))
+    assert(t.evaluate(fact('bar' => 41), [], Factbase.new))
+  end
+end

--- a/test/factbase/terms/test_exists.rb
+++ b/test/factbase/terms/test_exists.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2025 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+require_relative '../../test__helper'
+require_relative '../../../lib/factbase/term'
+require_relative '../../../lib/factbase/terms/exists'
+
+# Test for 'absent' term.
+# Author:: Yegor Bugayenko (yegor256@gmail.com)
+# Copyright:: Copyright (c) 2024-2025 Yegor Bugayenko
+# License:: MIT
+class TestExists < Factbase::Test
+  def test_exists
+    t = Factbase::Exists.new([:foo])
+    assert(t.evaluate(fact('foo' => 41), [], Factbase.new))
+    refute(t.evaluate(fact('bar' => 41), [], Factbase.new))
+  end
+end

--- a/test/factbase/terms/test_meta.rb
+++ b/test/factbase/terms/test_meta.rb
@@ -11,37 +11,6 @@ require_relative '../../../lib/factbase/term'
 # Copyright:: Copyright (c) 2024-2025 Yegor Bugayenko
 # License:: MIT
 class TestMeta < Factbase::Test
-  def test_exists
-    t = Factbase::Term.new(:exists, [:foo])
-    assert(t.evaluate(fact('foo' => 41), [], Factbase.new))
-    refute(t.evaluate(fact('bar' => 41), [], Factbase.new))
-  end
-
-  def test_absent
-    t = Factbase::Term.new(:absent, [:foo])
-    refute(t.evaluate(fact('foo' => 41), [], Factbase.new))
-    assert(t.evaluate(fact('bar' => 41), [], Factbase.new))
-  end
-
-  def test_size
-    t = Factbase::Term.new(:size, [:foo])
-    assert_equal(1, t.evaluate(fact('foo' => 41), [], Factbase.new))
-    assert_equal(0, t.evaluate(fact('foo' => nil), [], Factbase.new))
-    assert_equal(4, t.evaluate(fact('foo' => [1, 2, 3, 4]), [], Factbase.new))
-    assert_equal(0, t.evaluate(fact('foo' => []), [], Factbase.new))
-    assert_equal(1, t.evaluate(fact('foo' => ''), [], Factbase.new))
-  end
-
-  def test_type
-    t = Factbase::Term.new(:type, [:foo])
-    assert_equal('nil', t.evaluate(fact('foo' => nil), [], Factbase.new))
-    assert_equal('Integer', t.evaluate(fact('foo' => [1]), [], Factbase.new))
-    assert_equal('Array', t.evaluate(fact('foo' => [1, 2]), [], Factbase.new))
-    assert_equal('String', t.evaluate(fact('foo' => 'bar'), [], Factbase.new))
-    assert_equal('Float', t.evaluate(fact('foo' => 2.1), [], Factbase.new))
-    assert_equal('Time', t.evaluate(fact('foo' => Time.now), [], Factbase.new))
-  end
-
   def test_nil
     t = Factbase::Term.new(:nil, [:foo])
     assert(t.evaluate(fact('foo' => nil), [], Factbase.new))

--- a/test/factbase/terms/test_size.rb
+++ b/test/factbase/terms/test_size.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2025 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+require_relative '../../test__helper'
+require_relative '../../../lib/factbase/term'
+require_relative '../../../lib/factbase/terms/size'
+
+# Test for 'size' term.
+# Author:: Yegor Bugayenko (yegor256@gmail.com)
+# Copyright:: Copyright (c) 2024-2025 Yegor Bugayenko
+# License:: MIT
+class TestSize < Factbase::Test
+  def test_size
+    t = Factbase::Size.new([:foo])
+    assert_equal(1, t.evaluate(fact('foo' => 41), [], Factbase.new))
+    assert_equal(0, t.evaluate(fact('foo' => nil), [], Factbase.new))
+    assert_equal(4, t.evaluate(fact('foo' => [1, 2, 3, 4]), [], Factbase.new))
+    assert_equal(0, t.evaluate(fact('foo' => []), [], Factbase.new))
+    assert_equal(1, t.evaluate(fact('foo' => ''), [], Factbase.new))
+  end
+end

--- a/test/factbase/terms/test_type.rb
+++ b/test/factbase/terms/test_type.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2025 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+require_relative '../../test__helper'
+require_relative '../../../lib/factbase/term'
+require_relative '../../../lib/factbase/terms/type'
+
+# Test for 'type' term.
+# Author:: Yegor Bugayenko (yegor256@gmail.com)
+# Copyright:: Copyright (c) 2024-2025 Yegor Bugayenko
+# License:: MIT
+class TestType < Factbase::Test
+  def test_type
+    t = Factbase::Type.new([:foo])
+    assert_equal('nil', t.evaluate(fact('foo' => nil), [], Factbase.new))
+    assert_equal('Integer', t.evaluate(fact('foo' => [1]), [], Factbase.new))
+    assert_equal('Array', t.evaluate(fact('foo' => [1, 2]), [], Factbase.new))
+    assert_equal('String', t.evaluate(fact('foo' => 'bar'), [], Factbase.new))
+    assert_equal('Float', t.evaluate(fact('foo' => 2.1), [], Factbase.new))
+    assert_equal('Time', t.evaluate(fact('foo' => Time.now), [], Factbase.new))
+  end
+end


### PR DESCRIPTION
This PR refactors the `Factbase::Term` class by creating individual classes for 'exists', 'absent', 'size' and 'type' terms, improving code organization and readability.

Related to #302