### PR TITLE
refactor(#302): create separate classes for to_string and to_integer terms

### DIFF
--- a/lib/factbase/term.rb
+++ b/lib/factbase/term.rb
@@ -26,6 +26,8 @@ require_relative 'terms/type'
 require_relative 'terms/nil'
 require_relative 'terms/many'
 require_relative 'terms/one'
+require_relative 'terms/to_string'
+require_relative 'terms/to_integer'
 
 # Term.
 #
@@ -106,7 +108,9 @@ class Factbase::Term
       type: Factbase::Type.new(operands),
       nil: Factbase::Nil.new(operands),
       many: Factbase::Many.new(operands),
-      one: Factbase::One.new(operands)
+      one: Factbase::One.new(operands),
+      to_string: Factbase::ToString.new(operands),
+      to_integer: Factbase::ToInteger.new(operands)
     }
   end
 

--- a/lib/factbase/terms/casting.rb
+++ b/lib/factbase/terms/casting.rb
@@ -11,20 +11,6 @@ require_relative '../../factbase'
 # Copyright:: Copyright (c) 2024-2025 Yegor Bugayenko
 # License:: MIT
 module Factbase::Casting
-  def to_string(fact, maps, fb)
-    assert_args(1)
-    vv = _values(0, fact, maps, fb)
-    return nil if vv.nil?
-    vv[0].to_s
-  end
-
-  def to_integer(fact, maps, fb)
-    assert_args(1)
-    vv = _values(0, fact, maps, fb)
-    return nil if vv.nil?
-    vv[0].to_i
-  end
-
   def to_float(fact, maps, fb)
     assert_args(1)
     vv = _values(0, fact, maps, fb)

--- a/lib/factbase/terms/to_integer.rb
+++ b/lib/factbase/terms/to_integer.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2025 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+require_relative 'base'
+# Represents an integer conversion term 'to_integer'.
+# This class is used to evaluate a term and return its integer representation.
+class Factbase::ToInteger < Factbase::TermBase
+  # Constructor.
+  # @param [Array] operands Operands
+  def initialize(operands)
+    super()
+    @operands = operands
+  end
+
+  # Evaluate term on a fact.
+  # @param [Factbase::Fact] fact The fact
+  # @param [Array<Factbase::Fact>] maps All maps available
+  # @param [Factbase] fb Factbase to use for sub-queries
+  # @return [Integer] Integer representation of the value
+  def evaluate(fact, maps, fb)
+    assert_args(1)
+    vv = _values(0, fact, maps, fb)
+    return nil if vv.nil?
+    vv[0].to_i
+  end
+end

--- a/lib/factbase/terms/to_string.rb
+++ b/lib/factbase/terms/to_string.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2025 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+require_relative 'base'
+# Represents a string conversion term 'to_string'.
+# This class is used to evaluate a term and return its string representation.
+class Factbase::ToString < Factbase::TermBase
+  # Constructor.
+  # @param [Array] operands Operands
+  def initialize(operands)
+    super()
+    @operands = operands
+  end
+
+  # Evaluate term on a fact.
+  # @param [Factbase::Fact] fact The fact
+  # @param [Array<Factbase::Fact>] maps All maps available
+  # @param [Factbase] fb Factbase to use for sub-queries
+  # @return [String] The same value as string
+  def evaluate(fact, maps, fb)
+    assert_args(1)
+    vv = _values(0, fact, maps, fb)
+    return nil if vv.nil?
+    vv[0].to_s
+  end
+end

--- a/test/factbase/terms/test_casting.rb
+++ b/test/factbase/terms/test_casting.rb
@@ -11,16 +11,6 @@ require_relative '../../../lib/factbase/term'
 # Copyright:: Copyright (c) 2024-2025 Yegor Bugayenko
 # License:: MIT
 class TestCasting < Factbase::Test
-  def test_to_str
-    t = Factbase::Term.new(:to_string, [Time.now])
-    assert_equal('String', t.evaluate(fact, [], Factbase.new).class.to_s)
-  end
-
-  def test_to_integer
-    t = Factbase::Term.new(:to_integer, [[42, 'hello']])
-    assert_equal('Integer', t.evaluate(fact, [], Factbase.new).class.to_s)
-  end
-
   def test_to_float
     t = Factbase::Term.new(:to_float, [[3.14, 'hello']])
     assert_equal('Float', t.evaluate(fact, [], Factbase.new).class.to_s)

--- a/test/factbase/terms/test_sprintf.rb
+++ b/test/factbase/terms/test_sprintf.rb
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: MIT
 
 # Test for unique term.
-# Author:: Volodya Lombrozo (volodya.lombrozo@gmail.com)
+# Author:: Yegor Bugayenko (yegor256@gmail.com)
 # Copyright:: Copyright (c) 2024-2025 Yegor Bugayenko
 # License:: MIT
 

--- a/test/factbase/terms/test_to_integer.rb
+++ b/test/factbase/terms/test_to_integer.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2025 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+require_relative '../../test__helper'
+require_relative '../../../lib/factbase/term'
+require_relative '../../../lib/factbase/terms/to_integer'
+
+# Test for 'to_integer' term.
+# Author:: Yegor Bugayenko (yegor256@gmail.com)
+# Copyright:: Copyright (c) 2024-2025 Yegor Bugayenko
+# License:: MIT
+class TestToInteger < Factbase::Test
+  def test_to_integer
+    t = Factbase::ToInteger.new([[42, 'hello']])
+    assert_equal('Integer', t.evaluate(fact, [], Factbase.new).class.to_s)
+  end
+end

--- a/test/factbase/terms/test_to_string.rb
+++ b/test/factbase/terms/test_to_string.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2025 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+require_relative '../../test__helper'
+require_relative '../../../lib/factbase/term'
+require_relative '../../../lib/factbase/terms/to_string'
+
+# Test for 'to_string' term.
+# Author:: Yegor Bugayenko (yegor256@gmail.com)
+# Copyright:: Copyright (c) 2024-2025 Yegor Bugayenko
+# License:: MIT
+class TestToString < Factbase::Test
+  def test_to_str
+    t = Factbase::ToString.new([Time.now])
+    assert_equal('String', t.evaluate(fact, [], Factbase.new).class.to_s)
+  end
+end

--- a/test/factbase/terms/test_unique.rb
+++ b/test/factbase/terms/test_unique.rb
@@ -8,7 +8,7 @@ require_relative '../../../lib/factbase/term'
 require_relative '../../../lib/factbase/terms/unique'
 
 # Test for unique term.
-# Author:: Volodya Lombrozo (volodya.lombrozo@gmail.com)
+# Author:: Yegor Bugayenko (yegor256@gmail.com)
 # Copyright:: Copyright (c) 2024-2025 Yegor Bugayenko
 # License:: MIT
 class TestUnique < Factbase::Test


### PR DESCRIPTION
This PR refactors the `Factbase::Term` class by creating separate classes for `to_string` and `to_integer` terms, enhancing code organization.

Related to #302