### PR TITLE
feat(#302): create separate `Plus` term class for arithmetic operations

### DIFF
--- a/lib/factbase/term.rb
+++ b/lib/factbase/term.rb
@@ -33,6 +33,7 @@ require_relative 'terms/to_time'
 require_relative 'terms/sorted'
 require_relative 'terms/inverted'
 require_relative 'terms/head'
+require_relative 'terms/plus'
 
 # Term.
 #
@@ -114,7 +115,8 @@ class Factbase::Term
       to_time: Factbase::ToTime.new(operands),
       sorted: Factbase::Sorted.new(operands),
       inverted: Factbase::Inverted.new(operands),
-      head: Factbase::Head.new(operands)
+      head: Factbase::Head.new(operands),
+      plus: Factbase::Plus.new(operands)
     }
   end
 

--- a/lib/factbase/terms/arithmetic.rb
+++ b/lib/factbase/terms/arithmetic.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2025 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+require_relative 'base'
+
+# Factbase::Arithmetic is a class for performing arithmetic operations.
+class Factbase::Arithmetic < Factbase::TermBase
+  # Constructor.
+  # @param [Array] operands Operands
+  def initialize(operation, operands)
+    super()
+    @op = operation
+    @operands = operands
+  end
+
+  # Evaluate term on a fact.
+  # @param [Factbase::Fact] fact The fact
+  # @param [Array<Factbase::Fact>] maps All maps available
+  # @param [Factbase] fb Factbase to use for sub-queries
+  # @return [Object] The result of the arithmetic operation
+  def evaluate(fact, maps, fb)
+    assert_args(2)
+    lefts = _values(0, fact, maps, fb)
+    return nil if lefts.nil?
+    raise 'Too many values at first position, one expected' unless lefts.size == 1
+    rights = _values(1, fact, maps, fb)
+    return nil if rights.nil?
+    raise 'Too many values at second position, one expected' unless rights.size == 1
+    v = lefts[0]
+    r = rights[0]
+    if v.is_a?(Time) && r.is_a?(String)
+      (num, units) = r.split
+      num = num.to_i
+      r =
+        case units
+        when 'seconds', 'second'
+          num
+        when 'minutes', 'minute'
+          num * 60
+        when 'hours', 'hour'
+          num * 60 * 60
+        when 'days', 'day'
+          num * 60 * 60 * 24
+        when 'weeks', 'week'
+          num * 60 * 60 * 24 * 7
+        else
+          raise "Unknown time unit '#{units}' in '#{r}"
+        end
+    end
+    v.send(@op, r)
+  end
+end

--- a/lib/factbase/terms/math.rb
+++ b/lib/factbase/terms/math.rb
@@ -11,10 +11,6 @@ require_relative '../../factbase'
 # Copyright:: Copyright (c) 2024-2025 Yegor Bugayenko
 # License:: MIT
 module Factbase::Math
-  def plus(fact, maps, fb)
-    _arithmetic(:+, fact, maps, fb)
-  end
-
   def minus(fact, maps, fb)
     _arithmetic(:-, fact, maps, fb)
   end
@@ -69,6 +65,10 @@ module Factbase::Math
     end
   end
 
+  # @todo #302:30min Remove the _arithmetic method.
+  #  Currently, we use it because we are required to inject all thesse methods into Factbase::Term.
+  #  But we have Factbase::Arithmetic class for arithmetic operations.
+  #  When all the 'math' terms will use from Factbase::Arithmetic, we can remove this method.
   def _arithmetic(op, fact, maps, fb)
     assert_args(2)
     lefts = _values(0, fact, maps, fb)

--- a/lib/factbase/terms/plus.rb
+++ b/lib/factbase/terms/plus.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2025 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+require_relative 'base'
+require_relative 'arithmetic'
+
+# Represents a Plus term in the Factbase system.
+# This class is used to perform addition operations on operands.
+class Factbase::Plus < Factbase::TermBase
+  # Constructor.
+  # @param [Array] operands Operands
+  def initialize(operands)
+    super()
+    @plus = Factbase::Arithmetic.new(:+, operands)
+  end
+
+  # Evaluate term on a fact.
+  # @param [Factbase::Fact] fact The fact
+  # @param [Array<Factbase::Fact>] maps All maps available
+  # @param [Factbase] fb Factbase to use for sub-queries
+  # @return [Object] Result of the addition
+  def evaluate(fact, maps, fb)
+    @plus.evaluate(fact, maps, fb)
+  end
+end

--- a/test/factbase/terms/test_math.rb
+++ b/test/factbase/terms/test_math.rb
@@ -88,18 +88,6 @@ class TestMath < Factbase::Test
     refute(t.evaluate(fact('bar' => [100]), [], Factbase.new))
   end
 
-  def test_plus
-    t = Factbase::Term.new(:plus, [:foo, 42])
-    assert_equal(46, t.evaluate(fact('foo' => 4), [], Factbase.new))
-    assert_nil(t.evaluate(fact, [], Factbase.new))
-  end
-
-  def test_plus_time
-    t = Factbase::Term.new(:plus, [:foo, '12 days'])
-    assert_equal(Time.parse('2024-01-13'), t.evaluate(fact('foo' => Time.parse('2024-01-01')), [], Factbase.new))
-    assert_nil(t.evaluate(fact, [], Factbase.new))
-  end
-
   def test_minus
     t = Factbase::Term.new(:minus, [:foo, 42])
     assert_equal(58, t.evaluate(fact('foo' => 100), [], Factbase.new))

--- a/test/factbase/terms/test_plus.rb
+++ b/test/factbase/terms/test_plus.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2025 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+require_relative '../../test__helper'
+require_relative '../../../lib/factbase/term'
+require_relative '../../../lib/factbase/terms/plus'
+
+# Test for 'plus' term.
+# Author:: Yegor Bugayenko (yegor256@gmail.com)
+# Copyright:: Copyright (c) 2024-2025 Yegor Bugayenko
+# License:: MIT
+class TestPlus < Factbase::Test
+  def test_plus
+    t = Factbase::Plus.new([:foo, 42])
+    assert_equal(46, t.evaluate(fact('foo' => 4), [], Factbase.new))
+    assert_nil(t.evaluate(fact, [], Factbase.new))
+  end
+
+  def test_plus_time
+    t = Factbase::Plus.new([:foo, '12 days'])
+    assert_equal(Time.parse('2024-01-13'), t.evaluate(fact('foo' => Time.parse('2024-01-01')), [], Factbase.new))
+    assert_nil(t.evaluate(fact, [], Factbase.new))
+  end
+
+  def test_plus_time_seconds
+    time = Time.utc(2000, 1, 1, 0, 0, 21)
+    t = Factbase::Plus.new([:foo, '21 seconds'])
+    assert_equal(time + 21, t.evaluate(fact('foo' => time), [], Factbase.new))
+    assert_nil(t.evaluate(fact, [], Factbase.new))
+  end
+
+  def test_plus_time_minutesseconds
+    time = Time.utc(2000, 1, 1, 0, 21, 0)
+    t = Factbase::Plus.new([:foo, '21 minutes'])
+    assert_equal(time + (21 * 60), t.evaluate(fact('foo' => time), [], Factbase.new))
+    assert_nil(t.evaluate(fact, [], Factbase.new))
+  end
+
+  def test_plus_time_hoursminutes
+    time = Time.utc(2000, 1, 1, 21, 0, 0)
+    t = Factbase::Plus.new([:foo, '21 hours'])
+    assert_equal(time + (21 * 60 * 60), t.evaluate(fact('foo' => time), [], Factbase.new))
+    assert_nil(t.evaluate(fact, [], Factbase.new))
+  end
+
+  def test_plus_time_weeks
+    time = Time.utc(2000, 1, 1, 0, 0, 0)
+    t = Factbase::Plus.new([:foo, '3 weeks'])
+    assert_equal(time + (3 * 60 * 60 * 24 * 7), t.evaluate(fact('foo' => time), [], Factbase.new))
+    assert_nil(t.evaluate(fact, [], Factbase.new))
+  end
+end


### PR DESCRIPTION
This PR refactors the `Factbase` by introducing a dedicated `Factbase::Plus` class for addition operations, enhancing code organization and maintainability.

Related to #302