### PR TITLE
feat(#302): create separate classes for 'minus' and 'times' terms

### DIFF
--- a/lib/factbase/term.rb
+++ b/lib/factbase/term.rb
@@ -34,6 +34,8 @@ require_relative 'terms/sorted'
 require_relative 'terms/inverted'
 require_relative 'terms/head'
 require_relative 'terms/plus'
+require_relative 'terms/minus'
+require_relative 'terms/times'
 
 # Term.
 #
@@ -116,7 +118,9 @@ class Factbase::Term
       sorted: Factbase::Sorted.new(operands),
       inverted: Factbase::Inverted.new(operands),
       head: Factbase::Head.new(operands),
-      plus: Factbase::Plus.new(operands)
+      plus: Factbase::Plus.new(operands),
+      minus: Factbase::Minus.new(operands),
+      times: Factbase::Times.new(operands)
     }
   end
 

--- a/lib/factbase/terms/math.rb
+++ b/lib/factbase/terms/math.rb
@@ -11,14 +11,6 @@ require_relative '../../factbase'
 # Copyright:: Copyright (c) 2024-2025 Yegor Bugayenko
 # License:: MIT
 module Factbase::Math
-  def minus(fact, maps, fb)
-    _arithmetic(:-, fact, maps, fb)
-  end
-
-  def times(fact, maps, fb)
-    _arithmetic(:*, fact, maps, fb)
-  end
-
   def div(fact, maps, fb)
     _arithmetic(:/, fact, maps, fb)
   end
@@ -79,25 +71,6 @@ module Factbase::Math
     raise 'Too many values at second position, one expected' unless rights.size == 1
     v = lefts[0]
     r = rights[0]
-    if v.is_a?(Time) && r.is_a?(String)
-      (num, units) = r.split
-      num = num.to_i
-      r =
-        case units
-        when 'seconds', 'second'
-          num
-        when 'minutes', 'minute'
-          num * 60
-        when 'hours', 'hour'
-          num * 60 * 60
-        when 'days', 'day'
-          num * 60 * 60 * 24
-        when 'weeks', 'week'
-          num * 60 * 60 * 24 * 7
-        else
-          raise "Unknown time unit '#{units}' in '#{r}"
-        end
-    end
     v.send(op, r)
   end
 end

--- a/lib/factbase/terms/minus.rb
+++ b/lib/factbase/terms/minus.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2025 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+require_relative 'base'
+# This class represents a 'minus' term within the Factbase.
+# It performs a subtraction operation over the given operands.
+class Factbase::Minus < Factbase::TermBase
+  # Constructor.
+  # @param [Array] operands Operands
+  def initialize(operands)
+    super()
+    @minus = Factbase::Arithmetic.new(:-, operands)
+  end
+
+  # Evaluate term on a fact.
+  # @param [Factbase::Fact] fact The fact
+  # @param [Array<Factbase::Fact>] maps All maps available
+  # @param [Factbase] fb Factbase to use for sub-queries
+  # @return [Object] Result of the subtraction
+  def evaluate(fact, maps, fb)
+    @minus.evaluate(fact, maps, fb)
+  end
+end

--- a/lib/factbase/terms/times.rb
+++ b/lib/factbase/terms/times.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2025 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+require_relative 'base'
+# This class represents a 'times' term within the Factbase.
+# It performs a multiplication operation over the given operands.
+class Factbase::Times < Factbase::TermBase
+  # Constructor.
+  # @param [Array] operands Operands
+  def initialize(operands)
+    super()
+    @times = Factbase::Arithmetic.new(:*, operands)
+  end
+
+  # Evaluate term on a fact.
+  # @param [Factbase::Fact] fact The fact
+  # @param [Array<Factbase::Fact>] maps All maps available
+  # @param [Factbase] fb Factbase to use for sub-queries
+  # @return [Object] Result of the multiplication
+  def evaluate(fact, maps, fb)
+    @times.evaluate(fact, maps, fb)
+  end
+end

--- a/test/factbase/terms/test_minus.rb
+++ b/test/factbase/terms/test_minus.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2025 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+require_relative '../../test__helper'
+require_relative '../../../lib/factbase/term'
+require_relative '../../../lib/factbase/terms/minus'
+
+# Test for 'minus' term.
+# Author:: Yegor Bugayenko (yegor256@gmail.com)
+# Copyright:: Copyright (c) 2024-2025 Yegor Bugayenko
+# License:: MIT
+class TestMinus < Factbase::Test
+  def test_minus
+    t = Factbase::Minus.new([:foo, 42])
+    assert_equal(58, t.evaluate(fact('foo' => 100), [], Factbase.new))
+    assert_nil(t.evaluate(fact, [], Factbase.new))
+  end
+
+  def test_minus_time
+    t = Factbase::Minus.new([:foo, '4 hours'])
+    assert_equal(Time.parse('2024-01-01T06:04'),
+                 t.evaluate(fact('foo' => Time.parse('2024-01-01T10:04')), [], Factbase.new))
+    assert_nil(t.evaluate(fact, [], Factbase.new))
+  end
+
+  def test_minus_time_singular
+    t = Factbase::Minus.new([:foo, '1 hour'])
+    assert_equal(Time.parse('2024-01-01T09:04'),
+                 t.evaluate(fact('foo' => Time.parse('2024-01-01T10:04')), [], Factbase.new))
+    assert_nil(t.evaluate(fact, [], Factbase.new))
+  end
+end

--- a/test/factbase/terms/test_times.rb
+++ b/test/factbase/terms/test_times.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2025 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+require_relative '../../test__helper'
+require_relative '../../../lib/factbase/term'
+require_relative '../../../lib/factbase/terms/times'
+
+# Test for 'times' term.
+# Author:: Yegor Bugayenko (yegor256@gmail.com)
+# Copyright:: Copyright (c) 2024-2025 Yegor Bugayenko
+# License:: MIT
+class TestTimes < Factbase::Test
+  def test_times
+    t = Factbase::Times.new([:foo, 42])
+    assert_equal(4200, t.evaluate(fact('foo' => 100), [], Factbase.new))
+  end
+end


### PR DESCRIPTION
This PR refactors the `Factbase` implementation by creating separate classes for each term, specifically adding `Factbase::Minus` and `Factbase::Times`, enhancing code organization and maintainability.

Related to #302