### PR TITLE
fix(#355): `bench_query` and `bench_lots_facts` conflict

### DIFF
--- a/benchmark/bench_lots_facts.rb
+++ b/benchmark/bench_lots_facts.rb
@@ -11,7 +11,7 @@ def bench_lots_facts(bmk, fb)
   total.times do |i|
     f = fb.insert
     f.id = i
-    f.time = Time.now
+    f.created = Time.now
     f.label = %w[bug feature][rand(0..1)]
     f.rpository = 'factbase' if rand(0..1).zero?
   end

--- a/test/factbase/terms/test_math.rb
+++ b/test/factbase/terms/test_math.rb
@@ -88,6 +88,13 @@ class TestMath < Factbase::Test
     refute(t.evaluate(fact('bar' => [100]), [], Factbase.new))
   end
 
+  def test_gt_time_string
+    t = Factbase::Term.new(:gt, [:foo, '2024-03-23T03:21:43Z'])
+    assert_raises(RuntimeError, 'comparison of Time with String failed') do
+      t.evaluate(fact('foo' => [Time.now]), [], Factbase.new)
+    end
+  end
+
   def test_minus
     t = Factbase::Term.new(:minus, [:foo, 42])
     assert_equal(58, t.evaluate(fact('foo' => 100), [], Factbase.new))

--- a/test/factbase/test_query.rb
+++ b/test/factbase/test_query.rb
@@ -196,6 +196,16 @@ class TestQuery < Factbase::Test
     end
   end
 
+  def test_compare_time_with_the_past
+    maps = [
+      { 'time' => Time.now }
+    ]
+    q = Factbase::Query.new(maps, '(gt time \'2024-03-23T03:21:43Z\')', Factbase.new)
+    assert_raises(RuntimeError, 'comparison of Time with String failed') do
+      q.each.next
+    end
+  end
+
   def test_deleting_nothing
     maps = [
       { 'foo' => [42] },


### PR DESCRIPTION
This PR fixes the problem with these benchmarks.

The Issue:

`bench_query` creates a few facts with `Time.now.iso8601` attributes which are strings.
`bench_lots_facts` creates a few facts with `Time.now` attributes which are time values.
All the facts are saved in the same shared factbase.
When `bench_query` acquired facts by using `(gt time '2024-...)`, it let to the type conflict.

This PR fixes this conflict

Related to #355