### PR TITLE
feat(#302): create separate classes for div and zero terms in Factbase

### DIFF
--- a/lib/factbase/term.rb
+++ b/lib/factbase/term.rb
@@ -36,6 +36,8 @@ require_relative 'terms/head'
 require_relative 'terms/plus'
 require_relative 'terms/minus'
 require_relative 'terms/times'
+require_relative 'terms/div'
+require_relative 'terms/zero'
 
 # Term.
 #
@@ -120,7 +122,9 @@ class Factbase::Term
       head: Factbase::Head.new(operands),
       plus: Factbase::Plus.new(operands),
       minus: Factbase::Minus.new(operands),
-      times: Factbase::Times.new(operands)
+      times: Factbase::Times.new(operands),
+      div: Factbase::Div.new(operands),
+      zero: Factbase::Zero.new(operands)
     }
   end
 

--- a/lib/factbase/terms/div.rb
+++ b/lib/factbase/terms/div.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2025 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+require_relative 'base'
+# This class represents a 'div' term within the Factbase.
+# It performs a division operation over the given operands.
+class Factbase::Div < Factbase::TermBase
+  # Constructor.
+  # @param [Array] operands Operands
+  def initialize(operands)
+    super()
+    @div = Factbase::Arithmetic.new(:/, operands)
+  end
+
+  # Evaluate term on a fact.
+  # @param [Factbase::Fact] fact The fact
+  # @param [Array<Factbase::Fact>] maps All maps available
+  # @param [Factbase] fb Factbase to use for sub-queries
+  # @return [Object] Result of the division
+  def evaluate(fact, maps, fb)
+    @div.evaluate(fact, maps, fb)
+  end
+end

--- a/lib/factbase/terms/math.rb
+++ b/lib/factbase/terms/math.rb
@@ -11,17 +11,6 @@ require_relative '../../factbase'
 # Copyright:: Copyright (c) 2024-2025 Yegor Bugayenko
 # License:: MIT
 module Factbase::Math
-  def div(fact, maps, fb)
-    _arithmetic(:/, fact, maps, fb)
-  end
-
-  def zero(fact, maps, fb)
-    assert_args(1)
-    vv = _values(0, fact, maps, fb)
-    return false if vv.nil?
-    vv.any? { |v| (v.is_a?(Integer) || v.is_a?(Float)) && v.zero? }
-  end
-
   def eq(fact, maps, fb)
     _cmp(:==, fact, maps, fb)
   end
@@ -61,16 +50,5 @@ module Factbase::Math
   #  Currently, we use it because we are required to inject all thesse methods into Factbase::Term.
   #  But we have Factbase::Arithmetic class for arithmetic operations.
   #  When all the 'math' terms will use from Factbase::Arithmetic, we can remove this method.
-  def _arithmetic(op, fact, maps, fb)
-    assert_args(2)
-    lefts = _values(0, fact, maps, fb)
-    return nil if lefts.nil?
-    raise 'Too many values at first position, one expected' unless lefts.size == 1
-    rights = _values(1, fact, maps, fb)
-    return nil if rights.nil?
-    raise 'Too many values at second position, one expected' unless rights.size == 1
-    v = lefts[0]
-    r = rights[0]
-    v.send(op, r)
-  end
+  def _arithmetic(op, fact, maps, fb); end
 end

--- a/lib/factbase/terms/zero.rb
+++ b/lib/factbase/terms/zero.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2025 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+require_relative 'base'
+
+# The `zero` term that evaluates whether any of the operand values is zero when applied to a fact.
+class Factbase::Zero < Factbase::TermBase
+  # Constructor.
+  # @param [Array] operands Operands
+  def initialize(operands)
+    super()
+    @operands = operands
+  end
+
+  # Evaluate term on a fact.
+  # @param [Factbase::Fact] fact The fact
+  # @param [Array<Factbase::Fact>] maps All maps available
+  # @param [Factbase] fb Factbase to use for sub-queries
+  # @return [Boolean] True if any value is zero
+  def evaluate(fact, maps, fb)
+    assert_args(1)
+    vv = _values(0, fact, maps, fb)
+    return false if vv.nil?
+    vv.any? { |v| (v.is_a?(Integer) || v.is_a?(Float)) && v.zero? }
+  end
+end

--- a/test/factbase/terms/test_div.rb
+++ b/test/factbase/terms/test_div.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2025 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+require_relative '../../test__helper'
+require_relative '../../../lib/factbase/term'
+require_relative '../../../lib/factbase/terms/div'
+
+# Test for 'div' term.
+# Author:: Yegor Bugayenko (yegor256@gmail.com)
+# Copyright:: Copyright (c) 2024-2025 Yegor Bugayenko
+# License:: MIT
+class TestDiv < Factbase::Test
+  def test_div_numbers
+    t = Factbase::Div.new([:balance, 100])
+    assert_equal(420, t.evaluate(fact('balance' => 42_000), [], Factbase.new))
+  end
+
+  def test_div_times_not_supported
+    t = Factbase::Div.new([:warranty, Time.new(2024, 1, 1)])
+    assert_includes(
+      'undefined method \'/\' for an instance of Time',
+      assert_raises(NoMethodError) do
+        t.evaluate(fact('warranty' => Time.new(2026, 1, 1)), [], Factbase.new)
+      end.message
+    )
+  end
+end

--- a/test/factbase/terms/test_zero.rb
+++ b/test/factbase/terms/test_zero.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2025 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+require_relative '../../test__helper'
+require_relative '../../../lib/factbase/term'
+require_relative '../../../lib/factbase/terms/zero'
+
+# Test for 'zero' term.
+# Author:: Yegor Bugayenko (yegor256@gmail.com)
+# Copyright:: Copyright (c) 2024-2025 Yegor Bugayenko
+# License:: MIT
+class TestZero < Factbase::Test
+  def test_zero
+    t = Factbase::Zero.new([:foo])
+    assert(t.evaluate(fact('foo' => [0]), [], Factbase.new))
+    assert(t.evaluate(fact('foo' => [10, 5, 6, -8, 'hey', 0, 9, 'fdsf']), [], Factbase.new))
+    refute(t.evaluate(fact('foo' => [100]), [], Factbase.new))
+    refute(t.evaluate(fact('foo' => []), [], Factbase.new))
+    refute(t.evaluate(fact('bar' => []), [], Factbase.new))
+  end
+end


### PR DESCRIPTION
This PR refactors the `Factbase::Term` class by introducing separate classes for the `div` and `zero` terms, improving code organization and maintainability.

Related to #302