### PR TITLE
ci(#361): update Ruby version to 3.4

### DIFF
--- a/.github/workflows/rake.yml
+++ b/.github/workflows/rake.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-24.04, macos-15, windows-2022]
-        ruby: [3.3]
+        ruby: [3.4]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v5

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -29,7 +29,7 @@ GEM
       tago (~> 0.1)
     ellipsized (0.3.0)
     erb (5.1.3)
-    json (2.15.2)
+    json (2.16.0)
     language_server-protocol (3.17.0.5)
     lint_roller (1.1.0)
     logger (1.7.0)
@@ -127,6 +127,7 @@ PLATFORMS
   x64-mingw-ucrt
   x86_64-darwin-20
   x86_64-darwin-21
+  x86_64-darwin-24
   x86_64-linux
 
 DEPENDENCIES
@@ -147,4 +148,4 @@ DEPENDENCIES
   yard (~> 0.9)
 
 BUNDLED WITH
-   2.5.16
+   2.6.2

--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ Read
 [these guidelines](https://www.yegor256.com/2014/04/15/github-guidelines.html).
 Make sure your build is green before you contribute
 your pull request. You will need to have
-[Ruby](https://www.ruby-lang.org/en/) 3.2+ and
+[Ruby](https://www.ruby-lang.org/en/) 3.4+ and
 [Bundler](https://bundler.io/) installed. Then:
 
 ```bash

--- a/test/factbase/terms/test_math.rb
+++ b/test/factbase/terms/test_math.rb
@@ -114,4 +114,17 @@ class TestMath < Factbase::Test
                  t.evaluate(fact('foo' => Time.parse('2024-01-01T10:04')), [], Factbase.new))
     assert_nil(t.evaluate(fact, [], Factbase.new))
   end
+
+  # This test won't work on ruby versions prior to 3.4
+  # You can read more about it here:
+  # https://docs.ruby-lang.org/en/3.4/NEWS_md.html#label-Compatibility+issues
+  def test_div_times_not_supported
+    t = Factbase::Term.new(:div, [:birth, Time.new(2024, 1, 1)])
+    assert_includes(
+      assert_raises(RuntimeError) do
+        t.evaluate(fact('birth' => Time.new(2026, 1, 1)), [], Factbase.new)
+      end.message,
+      'undefined method \'/\' for an instance of Time'
+    )
+  end
 end


### PR DESCRIPTION
This PR updates the Ruby version in the GitHub Actions workflow to `3.4` and modifies the `Gemfile.lock` accordingly.
Seems rultor uses Ruby 3.4 - it's why some pipelines worked with ruby 3.3 and failed on rultor.

You can read more about it right here:

https://docs.ruby-lang.org/en/3.4/NEWS_md.html#label-Compatibility+issues

Fixes #361