### PR TITLE
refactor(#357): remove the _arithmetic method from math.rb

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -84,7 +84,7 @@ GEM
       rubocop-ast (>= 1.47.1, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 2.4.0, < 4.0)
-    rubocop-ast (1.47.1)
+    rubocop-ast (1.48.0)
       parser (>= 3.3.7.2)
       prism (~> 1.4)
     rubocop-minitest (0.38.2)

--- a/lib/factbase/terms/math.rb
+++ b/lib/factbase/terms/math.rb
@@ -45,10 +45,4 @@ module Factbase::Math
       end
     end
   end
-
-  # @todo #302:30min Remove the _arithmetic method.
-  #  Currently, we use it because we are required to inject all thesse methods into Factbase::Term.
-  #  But we have Factbase::Arithmetic class for arithmetic operations.
-  #  When all the 'math' terms will use from Factbase::Arithmetic, we can remove this method.
-  def _arithmetic(op, fact, maps, fb); end
 end


### PR DESCRIPTION
This PR resolves puzzle `302-2566871e` by removing the `_arithmetic` method from `Factbase::Math`.

Related to #357