### PR TITLE
refactor(#302): create Compare class for comparison operations in Factbase

### DIFF
--- a/lib/factbase/terms/arithmetic.rb
+++ b/lib/factbase/terms/arithmetic.rb
@@ -8,6 +8,7 @@ require_relative 'base'
 # Factbase::Arithmetic is a class for performing arithmetic operations.
 class Factbase::Arithmetic < Factbase::TermBase
   # Constructor.
+  # @param [Symbol] operation The arithmetic operation (e.g., :+, :-, :*, :/)
   # @param [Array] operands Operands
   def initialize(operation, operands)
     super()

--- a/lib/factbase/terms/compare.rb
+++ b/lib/factbase/terms/compare.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2025 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+require_relative 'base'
+# Term 'compare'.
+# Compares two values using a specified operation.
+class Factbase::Compare < Factbase::TermBase
+  # Constructor.
+  # @param [Symbol] operation Operation to perform, e.g. :>, :<, :<=, :>=, :==
+  # @param [Array] operands Operands
+  def initialize(operation, operands)
+    super()
+    @op = operation
+    @operands = operands
+  end
+
+  # Evaluate term on a fact.
+  # @param [Factbase::Fact] fact The fact
+  # @param [Array<Factbase::Fact>] maps All maps available
+  # @param [Factbase] fb Factbase to use for sub-queries
+  # @return [Boolean] The result of the comparison
+  def evaluate(fact, maps, fb)
+    assert_args(2)
+    lefts = _values(0, fact, maps, fb)
+    return false if lefts.nil?
+    rights = _values(1, fact, maps, fb)
+    return false if rights.nil?
+    lefts.any? do |l|
+      l = l.floor if l.is_a?(Time) && @op == :==
+      rights.any? do |r|
+        r = r.floor if r.is_a?(Time) && @op == :==
+        l.send(@op, r)
+      end
+    end
+  end
+end

--- a/lib/factbase/terms/math.rb
+++ b/lib/factbase/terms/math.rb
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: MIT
 
 require_relative '../../factbase'
+require_relative 'compare'
 
 # Math terms.
 #
@@ -12,37 +13,22 @@ require_relative '../../factbase'
 # License:: MIT
 module Factbase::Math
   def eq(fact, maps, fb)
-    _cmp(:==, fact, maps, fb)
+    Factbase::Compare.new(:==, @operands).evaluate(fact, maps, fb)
   end
 
   def lt(fact, maps, fb)
-    _cmp(:<, fact, maps, fb)
+    Factbase::Compare.new(:<, @operands).evaluate(fact, maps, fb)
   end
 
   def gt(fact, maps, fb)
-    _cmp(:>, fact, maps, fb)
+    Factbase::Compare.new(:>, @operands).evaluate(fact, maps, fb)
   end
 
   def lte(fact, maps, fb)
-    _cmp(:<=, fact, maps, fb)
+    Factbase::Compare.new(:<=, @operands).evaluate(fact, maps, fb)
   end
 
   def gte(fact, maps, fb)
-    _cmp(:>=, fact, maps, fb)
-  end
-
-  def _cmp(op, fact, maps, fb)
-    assert_args(2)
-    lefts = _values(0, fact, maps, fb)
-    return false if lefts.nil?
-    rights = _values(1, fact, maps, fb)
-    return false if rights.nil?
-    lefts.any? do |l|
-      l = l.floor if l.is_a?(Time) && op == :==
-      rights.any? do |r|
-        r = r.floor if r.is_a?(Time) && op == :==
-        l.send(op, r)
-      end
-    end
+    Factbase::Compare.new(:>=, @operands).evaluate(fact, maps, fb)
   end
 end

--- a/test/factbase/terms/test_compare.rb
+++ b/test/factbase/terms/test_compare.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2025 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+require_relative '../../test__helper'
+require_relative '../../../lib/factbase/term'
+require_relative '../../../lib/factbase/terms/compare'
+
+# Test for the 'compare' term.
+class TestCompare < Factbase::Test
+  def test_evaluates_comparison
+    t = Factbase::Compare.new(:>, [4, 2])
+    assert(t.evaluate(fact, [], Factbase.new), 'Expected 4 > 2 to be true')
+  end
+
+  def test_evaluates_comparison_less
+    t = Factbase::Compare.new(:<, [4, 2])
+    refute(t.evaluate(fact, [], Factbase.new), 'Expected 2 < 4 to be true')
+  end
+end


### PR DESCRIPTION
This PR refactors the `Factbase` implementation by introducing a new `Factbase::Compare` class, promoting cleaner design by separating term functionalities into distinct classes.

Related to #302