### PR TITLE
feat(#302): create separate classes for equality and less-than terms

### DIFF
--- a/lib/factbase/term.rb
+++ b/lib/factbase/term.rb
@@ -38,6 +38,8 @@ require_relative 'terms/minus'
 require_relative 'terms/times'
 require_relative 'terms/div'
 require_relative 'terms/zero'
+require_relative 'terms/eq'
+require_relative 'terms/lt'
 
 # Term.
 #
@@ -124,7 +126,9 @@ class Factbase::Term
       minus: Factbase::Minus.new(operands),
       times: Factbase::Times.new(operands),
       div: Factbase::Div.new(operands),
-      zero: Factbase::Zero.new(operands)
+      zero: Factbase::Zero.new(operands),
+      eq: Factbase::Eq.new(operands),
+      lt: Factbase::Lt.new(operands)
     }
   end
 

--- a/lib/factbase/terms/eq.rb
+++ b/lib/factbase/terms/eq.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2025 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+require_relative 'base'
+require_relative 'compare'
+
+# Represents an equality term in the Factbase.
+# This class encapsulates the evaluation of equality comparisons
+# between operands within the context of a Factbase.
+class Factbase::Eq < Factbase::TermBase
+  # Constructor.
+  # @param [Array] operands Operands
+  def initialize(operands)
+    super()
+    @op = Factbase::Compare.new(:==, operands)
+  end
+
+  # Evaluate term on a fact.
+  # @param [Factbase::Fact] fact The fact
+  # @param [Array<Factbase::Fact>] maps All maps available
+  # @param [Factbase] fb Factbase to use for sub-queries
+  # @return [Boolean] The result of the equality comparison
+  def evaluate(fact, maps, fb)
+    @op.evaluate(fact, maps, fb)
+  end
+end

--- a/lib/factbase/terms/lt.rb
+++ b/lib/factbase/terms/lt.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2025 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+require_relative 'base'
+require_relative 'compare'
+
+# Represents a less-than term in the Factbase system.
+# This class is used to evaluate whether a given fact satisfies
+# a less-than comparison with the specified operands.
+class Factbase::Lt < Factbase::TermBase
+  # Constructor.
+  # @param [Array] operands Operands
+  def initialize(operands)
+    super()
+    @op = Factbase::Compare.new(:<, operands)
+  end
+
+  # Evaluate term on a fact.
+  # @param [Factbase::Fact] fact The fact
+  # @param [Array<Factbase::Fact>] maps All maps available
+  # @param [Factbase] fb Factbase to use for sub-queries
+  # @return [Boolean] The result of the less-than comparison
+  def evaluate(fact, maps, fb)
+    @op.evaluate(fact, maps, fb)
+  end
+end

--- a/lib/factbase/terms/math.rb
+++ b/lib/factbase/terms/math.rb
@@ -12,14 +12,6 @@ require_relative 'compare'
 # Copyright:: Copyright (c) 2024-2025 Yegor Bugayenko
 # License:: MIT
 module Factbase::Math
-  def eq(fact, maps, fb)
-    Factbase::Compare.new(:==, @operands).evaluate(fact, maps, fb)
-  end
-
-  def lt(fact, maps, fb)
-    Factbase::Compare.new(:<, @operands).evaluate(fact, maps, fb)
-  end
-
   def gt(fact, maps, fb)
     Factbase::Compare.new(:>, @operands).evaluate(fact, maps, fb)
   end

--- a/test/factbase/terms/test_eq.rb
+++ b/test/factbase/terms/test_eq.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2025 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+#
+require_relative '../../test__helper'
+require_relative '../../../lib/factbase/term'
+require_relative '../../../lib/factbase/terms/eq'
+
+# Tests for the 'eq' term.
+# Author:: Volodya Lombrozo (volodya.lombrozo@gmail.com)
+# Copyright:: Copyright (c) 2024-2025 Yegor Bugayenko
+# License:: MIT
+class TestEq < Factbase::Test
+  def test_compares_equal
+    t = Factbase::Eq.new([:number, 42])
+    assert(t.evaluate(fact('number' => 42), [], Factbase.new))
+  end
+
+  def test_compares_not_equal
+    t = Factbase::Eq.new([:number, 42])
+    refute(t.evaluate(fact('number' => 100), [], Factbase.new))
+  end
+end

--- a/test/factbase/terms/test_lt.rb
+++ b/test/factbase/terms/test_lt.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2025 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+#
+require_relative '../../test__helper'
+require_relative '../../../lib/factbase/term'
+require_relative '../../../lib/factbase/terms/lt'
+
+# Tests for the 'lt' term.
+# Author:: Volodya Lombrozo (volodya.lombrozo@gmail.com)
+# Copyright:: Copyright (c) 2024-2025 Yegor Bugayenko
+# License:: MIT
+class TestLt < Factbase::Test
+  def test_compares_less_than
+    t = Factbase::Lt.new([:number, 42])
+    assert(t.evaluate(fact('number' => 10), [], Factbase.new))
+  end
+
+  def test_compares_not_less_than
+    t = Factbase::Lt.new([:number, 42])
+    refute(t.evaluate(fact('number' => 100), [], Factbase.new))
+  end
+end


### PR DESCRIPTION
This PR refactors the `Factbase` by introducing separate classes for the `eq` and `lt` terms, enhancing code organization.

Related to #302