### PR TITLE
refactor(#302): create separate classes for 'gt' and 'gte' terms in Factbase

### DIFF
--- a/lib/factbase/term.rb
+++ b/lib/factbase/term.rb
@@ -40,6 +40,8 @@ require_relative 'terms/div'
 require_relative 'terms/zero'
 require_relative 'terms/eq'
 require_relative 'terms/lt'
+require_relative 'terms/gt'
+require_relative 'terms/gte'
 
 # Term.
 #
@@ -128,7 +130,9 @@ class Factbase::Term
       div: Factbase::Div.new(operands),
       zero: Factbase::Zero.new(operands),
       eq: Factbase::Eq.new(operands),
-      lt: Factbase::Lt.new(operands)
+      lt: Factbase::Lt.new(operands),
+      gt: Factbase::Gt.new(operands),
+      gte: Factbase::Gte.new(operands)
     }
   end
 

--- a/lib/factbase/terms/gt.rb
+++ b/lib/factbase/terms/gt.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2025 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+require_relative 'base'
+require_relative 'compare'
+
+# Represents a greater-than comparison term in the Factbase.
+# This class is used to evaluate whether a given fact satisfies
+# the greater-than condition with the provided operands.
+class Factbase::Gt < Factbase::TermBase
+  # Constructor.
+  # @param [Array] operands Operands
+  def initialize(operands)
+    super()
+    @op = Factbase::Compare.new(:>, operands)
+  end
+
+  # Evaluate term on a fact.
+  # @param [Factbase::Fact] fact The fact
+  # @param [Array<Factbase::Fact>] maps All maps available
+  # @param [Factbase] fb Factbase to use for sub-queries
+  # @return [Boolean] The result of the greater-than comparison
+  def evaluate(fact, maps, fb)
+    @op.evaluate(fact, maps, fb)
+  end
+end

--- a/lib/factbase/terms/gte.rb
+++ b/lib/factbase/terms/gte.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2025 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+require_relative 'base'
+require_relative 'compare'
+
+# It represents a term for evaluating whether a set of operands satisfies
+# the "greater-than-or-equal-to" (>=) condition within the context of a factbase.
+class Factbase::Gte < Factbase::TermBase
+  # Constructor.
+  # @param [Array] operands Operands
+  def initialize(operands)
+    super()
+    @op = Factbase::Compare.new(:>=, operands)
+  end
+
+  # Evaluate term on a fact.
+  # @param [Factbase::Fact] fact The fact
+  # @param [Array<Factbase::Fact>] maps All maps available
+  # @param [Factbase] fb Factbase to use for sub-queries
+  # @return [Boolean] The result of the greater-than-or-equal comparison
+  def evaluate(fact, maps, fb)
+    @op.evaluate(fact, maps, fb)
+  end
+end

--- a/lib/factbase/terms/math.rb
+++ b/lib/factbase/terms/math.rb
@@ -12,15 +12,7 @@ require_relative 'compare'
 # Copyright:: Copyright (c) 2024-2025 Yegor Bugayenko
 # License:: MIT
 module Factbase::Math
-  def gt(fact, maps, fb)
-    Factbase::Compare.new(:>, @operands).evaluate(fact, maps, fb)
-  end
-
   def lte(fact, maps, fb)
     Factbase::Compare.new(:<=, @operands).evaluate(fact, maps, fb)
-  end
-
-  def gte(fact, maps, fb)
-    Factbase::Compare.new(:>=, @operands).evaluate(fact, maps, fb)
   end
 end

--- a/test/factbase/terms/test_gt.rb
+++ b/test/factbase/terms/test_gt.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2025 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+#
+require_relative '../../test__helper'
+require_relative '../../../lib/factbase/term'
+require_relative '../../../lib/factbase/terms/gt'
+
+# Tests for the 'gt' term.
+# Author:: Volodya Lombrozo (volodya.lombrozo@gmail.com)
+# Copyright:: Copyright (c) 2024-2025 Yegor Bugayenko
+# License:: MIT
+class TestGt < Factbase::Test
+  def test_compares_greater_than
+    t = Factbase::Gt.new([:number, 42])
+    assert(t.evaluate(fact('number' => 100), [], Factbase.new))
+  end
+
+  def test_compares_not_greater_than
+    t = Factbase::Gt.new([:number, 42])
+    refute(t.evaluate(fact('number' => 10), [], Factbase.new))
+  end
+end

--- a/test/factbase/terms/test_gte.rb
+++ b/test/factbase/terms/test_gte.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2025 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+require_relative '../../test__helper'
+require_relative '../../../lib/factbase/term'
+require_relative '../../../lib/factbase/terms/gte'
+
+# Tests for the 'gte' term.
+# Author:: Volodya Lombrozo (volodya.lombrozo@gmail.com)
+# Copyright:: Copyright (c) 2024-2025 Yegor Bugayenko
+# License:: MIT
+class TestGte < Factbase::Test
+  def test_compares_greater_than_or_equal
+    t = Factbase::Gte.new([:number, 42])
+    assert(t.evaluate(fact('number' => 42), [], Factbase.new))
+    assert(t.evaluate(fact('number' => 100), [], Factbase.new))
+  end
+
+  def test_compares_not_greater_than_or_equal
+    t = Factbase::Gte.new([:number, 42])
+    refute(t.evaluate(fact('number' => 41), [], Factbase.new))
+  end
+end


### PR DESCRIPTION
This PR refactors the `Factbase` by creating individual classes for 'gt' and 'gte' terms.

Related to #302