### PR TITLE
fix(#355):  fresh factbase for each benchmark

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -57,15 +57,15 @@ desc 'Benchmark them all'
 task :benchmark, [:name] do |_t, args|
   bname = args[:name] || 'all'
   require_relative 'lib/factbase'
-  fb = Factbase.new
   require_relative 'lib/factbase/cached/cached_factbase'
-  fb = Factbase::CachedFactbase.new(fb)
   require_relative 'lib/factbase/indexed/indexed_factbase'
-  fb = Factbase::IndexedFactbase.new(fb)
   require_relative 'lib/factbase/sync/sync_factbase'
-  fb = Factbase::SyncFactbase.new(fb)
   require 'benchmark'
   Benchmark.bm(60) do |b|
+    fb = Factbase.new
+    fb = Factbase::CachedFactbase.new(fb)
+    fb = Factbase::IndexedFactbase.new(fb)
+    fb = Factbase::SyncFactbase.new(fb)
     if bname == 'all'
       Dir['benchmark/bench_*.rb'].each do |f|
         require_relative f

--- a/benchmark/bench_empty.rb
+++ b/benchmark/bench_empty.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2025 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+require_relative '../lib/factbase'
+
+def bench_empty(bmk, fb)
+  bmk.report('query all facts from an empty factbase') do
+    size = fb.query('(always)').count
+    raise "Expected zero facts in an empty factbase, got #{size}" unless size.zero?
+  end
+end

--- a/lib/factbase/cached/cached_query.rb
+++ b/lib/factbase/cached/cached_query.rb
@@ -12,6 +12,8 @@ require_relative 'cached_fact'
 # Copyright:: Copyright (c) 2024-2025 Yegor Bugayenko
 # License:: MIT
 class Factbase::CachedQuery
+  include Enumerable
+
   # Constructor.
   # @param [Factbase::Query] origin Original query
   # @param [Hash] cache The cache

--- a/lib/factbase/indexed/indexed_query.rb
+++ b/lib/factbase/indexed/indexed_query.rb
@@ -12,6 +12,8 @@ require_relative 'indexed_fact'
 # Copyright:: Copyright (c) 2024-2025 Yegor Bugayenko
 # License:: MIT
 class Factbase::IndexedQuery
+  include Enumerable
+
   # Constructor.
   # @param [Factbase::Query] origin Original query
   # @param [Hash] idx The index

--- a/lib/factbase/query.rb
+++ b/lib/factbase/query.rb
@@ -20,6 +20,8 @@ require_relative 'tee'
 # Copyright:: Copyright (c) 2024-2025 Yegor Bugayenko
 # License:: MIT
 class Factbase::Query
+  include Enumerable
+
   # Constructor.
   # @param [Array<Fact>] maps Array of facts to start with
   # @param [String|Factbase::Term] term The query term

--- a/lib/factbase/sync/sync_query.rb
+++ b/lib/factbase/sync/sync_query.rb
@@ -11,6 +11,8 @@ require_relative '../../factbase'
 # Copyright:: Copyright (c) 2024-2025 Yegor Bugayenko
 # License:: MIT
 class Factbase::SyncQuery
+  include Enumerable
+
   # Constructor.
   # @param [Factbase::Query] origin Original query
   # @param [Monitor] monitor The monitor

--- a/test/factbase/test_query.rb
+++ b/test/factbase/test_query.rb
@@ -77,6 +77,15 @@ class TestQuery < Factbase::Test
     )
   end
 
+  def test_retrieves_all_facts
+    maps = []
+    maps << { 'first' => 'first' }
+    maps << { 'second' => 'second' }
+    maps << { 'third' => 'third' }
+    q = Factbase::Query.new(maps, '(always)', Factbase.new)
+    assert_equal(3, q.count)
+  end
+
   def test_complex_parsing
     queries = {
       '(eq num 444)' => 0,


### PR DESCRIPTION
The original issue was related to the collision happened between benchmarks. Thus, I suggest making them independent.

Related to #355