### PR TITLE
feat(#302): create separate classes for 'always' and 'never' terms

### DIFF
--- a/lib/factbase/term.rb
+++ b/lib/factbase/term.rb
@@ -43,6 +43,8 @@ require_relative 'terms/lt'
 require_relative 'terms/lte'
 require_relative 'terms/gt'
 require_relative 'terms/gte'
+require_relative 'terms/always'
+require_relative 'terms/never'
 
 # Term.
 #
@@ -131,7 +133,9 @@ class Factbase::Term
       lt: Factbase::Lt.new(operands),
       lte: Factbase::Lte.new(operands),
       gt: Factbase::Gt.new(operands),
-      gte: Factbase::Gte.new(operands)
+      gte: Factbase::Gte.new(operands),
+      always: Factbase::Always.new(operands),
+      never: Factbase::Never.new(operands)
     }
   end
 

--- a/lib/factbase/terms/always.rb
+++ b/lib/factbase/terms/always.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2025 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+require_relative 'base'
+# The term 'always' that always evaluates to true.
+# If you want to return all the facts you might use '(always)' query.
+class Factbase::Always < Factbase::TermBase
+  # Constructor.
+  # @param [Array] operands Operands
+  def initialize(operands)
+    super()
+    @operands = operands
+    @op = :always
+  end
+
+  # Evaluate term on a fact.
+  # @param [Factbase::Fact] _fact The fact
+  # @param [Array<Factbase::Fact>] _maps All maps available
+  # @param [Factbase] _fb Factbase to use for sub-queries
+  # @return [Boolean] Always returns true
+  def evaluate(_fact, _maps, _fb)
+    assert_args(0)
+    true
+  end
+end

--- a/lib/factbase/terms/logical.rb
+++ b/lib/factbase/terms/logical.rb
@@ -11,24 +11,6 @@ require_relative '../../factbase'
 # Copyright:: Copyright (c) 2024-2025 Yegor Bugayenko
 # License:: MIT
 module Factbase::Logical
-  # Always returns true, regardless of the fact
-  # @param [Factbase::Fact] _fact The fact (unused)
-  # @param [Array<Factbase::Fact>] _maps All maps available (unused)
-  # @return [Boolean] Always returns true
-  def always(_fact, _maps, _fb)
-    assert_args(0)
-    true
-  end
-
-  # Always returns false, regardless of the fact
-  # @param [Factbase::Fact] _fact The fact (unused)
-  # @param [Array<Factbase::Fact>] _maps All maps available (unused)
-  # @return [Boolean] Always returns false
-  def never(_fact, _maps, _fb)
-    assert_args(0)
-    false
-  end
-
   # Logical negation (NOT) of an operand
   # @param [Factbase::Fact] fact The fact
   # @param [Array<Factbase::Fact>] maps All maps available

--- a/lib/factbase/terms/never.rb
+++ b/lib/factbase/terms/never.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2025 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+require_relative 'base'
+# The term 'never' that never evaluates to true.
+class Factbase::Never < Factbase::TermBase
+  # Constructor.
+  # @param [Array] operands Operands
+  def initialize(operands)
+    super()
+    @operands = operands
+    @op = :never
+  end
+
+  # Evaluate term on a fact.
+  # @param [Factbase::Fact] _fact The fact
+  # @param [Array<Factbase::Fact>] _maps All maps available
+  # @param [Factbase] _fb Factbase to use for sub-queries
+  # @return [Boolean] Always returns false
+  def evaluate(_fact, _maps, _fb)
+    assert_args(0)
+    false
+  end
+end

--- a/test/factbase/terms/test_always.rb
+++ b/test/factbase/terms/test_always.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2025 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+require_relative '../../test__helper'
+require_relative '../../../lib/factbase/term'
+require_relative '../../../lib/factbase/terms/always'
+
+# Test for the 'always' term.
+# Author:: Volodya Lombrozo (volodya.lombrozo@gmail.com)
+# Copyright:: Copyright (c) 2024-2025 Yegor Bugayenko
+# License:: MIT
+class TestAlways < Factbase::Test
+  def test_always
+    t = Factbase::Always.new([])
+    assert(t.evaluate(fact, [], Factbase.new))
+    assert(t.evaluate(fact('foo' => 41), [], Factbase.new))
+  end
+
+  def test_always_with_arguments
+    assert_includes(assert_raises(RuntimeError) do
+      Factbase::Term.new(:always, %i[foo bar]).evaluate(fact('foo' => 1, 'bar' => 'a'), [], Factbase.new)
+    end.message, "Too many (2) operands for 'always' (0 expected)")
+  end
+end

--- a/test/factbase/terms/test_never.rb
+++ b/test/factbase/terms/test_never.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2025 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+require_relative '../../test__helper'
+require_relative '../../../lib/factbase/term'
+require_relative '../../../lib/factbase/terms/never'
+
+# Test for the 'never' term.
+# Author:: Volodya Lombrozo (volodya.lombrozo@gmail.com)
+# Copyright:: Copyright (c) 2024-2025 Yegor Bugayenko
+# License:: MIT
+class TestNever < Factbase::Test
+  def test_never
+    t = Factbase::Never.new([])
+    refute(t.evaluate(fact, [], Factbase.new))
+    refute(t.evaluate(fact('foo' => 41), [], Factbase.new))
+  end
+
+  def test_never_with_arguments
+    assert_includes(assert_raises(RuntimeError) do
+      Factbase::Term.new(:never, %i[foo bar]).evaluate(fact('foo' => 1, 'bar' => 'a'), [], Factbase.new)
+    end.message, "Too many (2) operands for 'never' (0 expected)")
+  end
+end


### PR DESCRIPTION
This PR refactors the `Factbase::Term` class by introducing separate classes for the `always` and `never` terms.

Related to #302