### PR TITLE
feat(#389): add benchmark gem to Gemfile to avoid deprecation warning

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@
 source 'https://rubygems.org'
 gemspec
 
+gem 'benchmark', '~>0.5', require: false
 gem 'minitest', '~>5.25', require: false
 gem 'minitest-reporters', '~>1.7', require: false
 gem 'os', '~>1.1', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -19,6 +19,7 @@ GEM
     ansi (1.5.0)
     ast (2.4.3)
     backtrace (0.4.1)
+    benchmark (0.5.0)
     builder (3.3.0)
     concurrent-ruby (1.3.5)
     date (3.5.0)
@@ -28,7 +29,7 @@ GEM
       loog (~> 0.6)
       tago (~> 0.1)
     ellipsized (0.3.0)
-    erb (5.1.3)
+    erb (6.0.0)
     json (2.16.0)
     language_server-protocol (3.17.0.5)
     lint_roller (1.1.0)
@@ -108,7 +109,7 @@ GEM
       simplecov (~> 0.19)
     simplecov-html (0.13.2)
     simplecov_json_formatter (0.1.4)
-    stringio (3.1.7)
+    stringio (3.1.8)
     tago (0.4.0)
     threads (0.4.1)
       backtrace (~> 0)
@@ -131,6 +132,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  benchmark (~> 0.5)
   factbase!
   minitest (~> 5.25)
   minitest-reporters (~> 1.7)


### PR DESCRIPTION
This PR adds the `benchmark` gem to the `Gemfile` to address warnings related to its removal from default gems in Ruby 3.5.0.

Fixes #389