### PR TITLE
feat(#302): add 'not' term class

### DIFF
--- a/lib/factbase/terms/boolean.rb
+++ b/lib/factbase/terms/boolean.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2025 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+require_relative 'base'
+# Boolean value checker.
+class Factbase::Boolean
+  # Constructor.
+  # @param [Object] val The value to check
+  # @param [Object] from The source of the value (for error messages)
+  # @return [Boolean] The boolean value
+  # @raise [RuntimeError] If value is not a boolean
+  def initialize(val, from)
+    @val = val
+    @from = from
+  end
+
+  # @return [Boolean] The boolean value
+  # @raise [RuntimeError] If value is not a boolean
+  def bool?
+    val = @val
+    val = val[0] if val.respond_to?(:each)
+    return false if val.nil?
+    return val if val.is_a?(TrueClass) || val.is_a?(FalseClass)
+    raise "Boolean is expected, while #{val.class} received from #{@from}"
+  end
+end

--- a/lib/factbase/terms/not.rb
+++ b/lib/factbase/terms/not.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2025 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+require_relative 'base'
+require_relative 'boolean'
+# The 'not' term that negates a boolean operand.
+# Logical negation (NOT) of an operand.
+class Factbase::Not < Factbase::TermBase
+  # Constructor.
+  # @param [Array] operands Operands
+  def initialize(operands)
+    super()
+    @operands = operands
+    @op = :not
+  end
+
+  # Evaluate term on a fact.
+  # @param [Factbase::Fact] fact The fact
+  # @param [Array<Factbase::Fact>] maps All maps available
+  # @return [Boolean] Negated boolean result of the operand
+  def evaluate(fact, maps, fb)
+    assert_args(1)
+    !Factbase::Boolean.new(_values(0, fact, maps, fb), @operands[0]).bool?
+  end
+end

--- a/lib/factbase/terms/shared.rb
+++ b/lib/factbase/terms/shared.rb
@@ -49,6 +49,7 @@ module Factbase::TermShared
   def _values(pos, fact, maps, fb)
     v = @operands[pos]
     v = v.evaluate(fact, maps, fb) if v.is_a?(Factbase::Term)
+    v = v.evaluate(fact, maps, fb) if v.is_a?(Factbase::TermBase)
     v = fact[v.to_s] if v.is_a?(Symbol)
     return v if v.nil?
     unless v.is_a?(Array)

--- a/test/factbase/terms/test_boolean.rb
+++ b/test/factbase/terms/test_boolean.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2025 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+require_relative '../../test__helper'
+require_relative '../../../lib/factbase/terms/boolean'
+
+# Test for the 'boolean'.
+# Author:: Volodya Lombrozo (volodya.lombrozo@gmail.com)
+# Copyright:: Copyright (c) 2024-2025 Yegor Bugayenko
+# License:: MIT
+class TestBoolean < Factbase::Test
+  def test_first_element
+    b = Factbase::Boolean.new([true, false], 'test_source')
+    assert_predicate(b, :bool?)
+  end
+
+  def test_first_element_false
+    b = Factbase::Boolean.new([false, true], 'test_source')
+    refute_predicate(b, :bool?)
+  end
+
+  def test_direct_true
+    b = Factbase::Boolean.new(true, 'test_source')
+    assert_predicate(b, :bool?)
+  end
+
+  def test_direct_false
+    b = Factbase::Boolean.new(false, 'test_source')
+    refute_predicate(b, :bool?)
+  end
+
+  def test_nil_value
+    b = Factbase::Boolean.new(nil, 'test_source')
+    refute_predicate(b, :bool?)
+  end
+
+  def test_invalid_value
+    b = Factbase::Boolean.new(42, 'test_source')
+    error = assert_raises(RuntimeError) { b.bool? }
+    assert_includes(error.message, 'Boolean is expected, while Integer received from test_source')
+  end
+end

--- a/test/factbase/terms/test_not.rb
+++ b/test/factbase/terms/test_not.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2025 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+require_relative '../../test__helper'
+require_relative '../../../lib/factbase/term'
+require_relative '../../../lib/factbase/terms/not'
+
+# Test for the 'not' term.
+# Author:: Volodya Lombrozo (volodya.lombrozo@gmail.com)
+# Copyright:: Copyright (c) 2024-2025 Yegor Bugayenko
+# License:: MIT
+class TestNot < Factbase::Test
+  def test_not
+    refute(Factbase::Not.new([Factbase::Always.new([])]).evaluate(fact, [], Factbase.new))
+  end
+
+  def test_not_reverse
+    assert(Factbase::Not.new([Factbase::Never.new([])]).evaluate(fact, [], Factbase.new))
+  end
+
+  def test_not_with_arguments
+    assert_includes(assert_raises(RuntimeError) do
+      Factbase::Term.new(:not, %i[foo bar]).evaluate(fact('foo' => true, 'bar' => false), [], Factbase.new)
+    end.message, "Too many (2) operands for 'not' (1 expected)")
+  end
+end


### PR DESCRIPTION
This PR introduces separate class for the 'not' term and adds an utility class 'Boolean'.

Related to #302