### PR TITLE
refactor(#302): separate logical terms 'and' and 'or' into individual classes

### DIFF
--- a/lib/factbase/term.rb
+++ b/lib/factbase/term.rb
@@ -45,6 +45,9 @@ require_relative 'terms/gt'
 require_relative 'terms/gte'
 require_relative 'terms/always'
 require_relative 'terms/never'
+require_relative 'terms/not'
+require_relative 'terms/or'
+require_relative 'terms/and'
 
 # Term.
 #
@@ -135,7 +138,10 @@ class Factbase::Term
       gt: Factbase::Gt.new(operands),
       gte: Factbase::Gte.new(operands),
       always: Factbase::Always.new(operands),
-      never: Factbase::Never.new(operands)
+      never: Factbase::Never.new(operands),
+      not: Factbase::Not.new(operands),
+      or: Factbase::Or.new(operands),
+      and: Factbase::And.new(operands)
     }
   end
 

--- a/lib/factbase/terms/and.rb
+++ b/lib/factbase/terms/and.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2025 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+require_relative 'base'
+require_relative 'boolean'
+# The 'and' term that represents a logical AND operation between multiple operands.
+class Factbase::And < Factbase::TermBase
+  # Constructor.
+  # @param [Array] operands Operands
+  def initialize(operands)
+    super()
+    @operands = operands
+    @op = :and
+  end
+
+  # Evaluate term on a fact.
+  # @param [Factbase::Fact] fact The fact
+  # @param [Array<Factbase::Fact>] maps All maps available
+  # @return [Boolean] True if all operands evaluate to true, false otherwise
+  def evaluate(fact, maps, fb)
+    (0..(@operands.size - 1)).each do |i|
+      return false unless Factbase::Boolean.new(_values(i, fact, maps, fb), @operands[i]).bool?
+    end
+    true
+  end
+end

--- a/lib/factbase/terms/logical.rb
+++ b/lib/factbase/terms/logical.rb
@@ -11,37 +11,6 @@ require_relative '../../factbase'
 # Copyright:: Copyright (c) 2024-2025 Yegor Bugayenko
 # License:: MIT
 module Factbase::Logical
-  # Logical negation (NOT) of an operand
-  # @param [Factbase::Fact] fact The fact
-  # @param [Array<Factbase::Fact>] maps All maps available
-  # @return [Boolean] Negated boolean result of the operand
-  def not(fact, maps, fb)
-    assert_args(1)
-    !_only_bool(_values(0, fact, maps, fb), 0)
-  end
-
-  # Logical OR of multiple operands
-  # @param [Factbase::Fact] fact The fact
-  # @param [Array<Factbase::Fact>] maps All maps available
-  # @return [Boolean] True if any operand evaluates to true, false otherwise
-  def or(fact, maps, fb)
-    (0..(@operands.size - 1)).each do |i|
-      return true if _only_bool(_values(i, fact, maps, fb), i)
-    end
-    false
-  end
-
-  # Logical AND of multiple operands
-  # @param [Factbase::Fact] fact The fact
-  # @param [Array<Factbase::Fact>] maps All maps available
-  # @return [Boolean] True if all operands evaluate to true, false otherwise
-  def and(fact, maps, fb)
-    (0..(@operands.size - 1)).each do |i|
-      return false unless _only_bool(_values(i, fact, maps, fb), i)
-    end
-    true
-  end
-
   # Logical implication (IF...THEN)
   # @param [Factbase::Fact] fact The fact
   # @param [Array<Factbase::Fact>] maps All maps available
@@ -90,17 +59,5 @@ module Factbase::Logical
   # @return [Factbase::Term] Simplified term
   def or_simplify
     and_or_simplify
-  end
-
-  # Helper method to ensure a value is boolean
-  # @param [Object] val The value to check
-  # @param [Integer] pos The position of the operand
-  # @return [Boolean] The boolean value
-  # @raise [RuntimeError] If value is not a boolean
-  def _only_bool(val, pos)
-    val = val[0] if val.respond_to?(:each)
-    return false if val.nil?
-    return val if val.is_a?(TrueClass) || val.is_a?(FalseClass)
-    raise "Boolean is expected, while #{val.class} received from #{@operands[pos]}"
   end
 end

--- a/lib/factbase/terms/or.rb
+++ b/lib/factbase/terms/or.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2025 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+require_relative 'base'
+require_relative 'boolean'
+# The 'or' term that represents a logical OR operation between multiple operands.
+class Factbase::Or < Factbase::TermBase
+  # Constructor.
+  # @param [Array] operands Operands
+  def initialize(operands)
+    super()
+    @operands = operands
+    @op = :or
+  end
+
+  # Evaluate term on a fact.
+  # @param [Factbase::Fact] fact The fact
+  # @param [Array<Factbase::Fact>] maps All maps available
+  # @return [Boolean] True if any operand evaluates to true, false otherwise
+  def evaluate(fact, maps, fb)
+    (0..(@operands.size - 1)).each do |i|
+      return true if Factbase::Boolean.new(_values(i, fact, maps, fb), @operands[i]).bool?
+    end
+    false
+  end
+end

--- a/test/factbase/terms/test_and.rb
+++ b/test/factbase/terms/test_and.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2025 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+require_relative '../../test__helper'
+require_relative '../../../lib/factbase/term'
+require_relative '../../../lib/factbase/terms/and'
+
+# Test for the 'and' term.
+# Author:: Volodya Lombrozo (volodya.lombrozo@gmail.com)
+# Copyright:: Copyright (c) 2024-2025 Yegor Bugayenko
+# License:: MIT
+class TestAnd < Factbase::Test
+  def test_and_true
+    assert(Factbase::And.new([Factbase::Always.new([]), Factbase::Always.new([])]).evaluate(fact, [], Factbase.new))
+  end
+
+  def test_and_false
+    refute(Factbase::And.new([Factbase::Always.new([]), Factbase::Never.new([])]).evaluate(fact, [], Factbase.new))
+  end
+end

--- a/test/factbase/terms/test_defn.rb
+++ b/test/factbase/terms/test_defn.rb
@@ -20,7 +20,8 @@ class TestDefn < Factbase::Test
   end
 
   def test_defn_again_by_mistake
-    t = Factbase::Defn.new([:and, 'self.to_s'])
+    t = Factbase::Defn.new([:unexisting_function, 'self.to_s'])
+    t.evaluate(fact, [], Factbase.new)
     assert_raises(StandardError) do
       t.evaluate(fact, [], Factbase.new)
     end

--- a/test/factbase/terms/test_or.rb
+++ b/test/factbase/terms/test_or.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2025 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+require_relative '../../test__helper'
+require_relative '../../../lib/factbase/term'
+require_relative '../../../lib/factbase/terms/or'
+
+# Test for the 'or' term.
+# Author:: Volodya Lombrozo (volodya.lombrozo@gmail.com)
+# Copyright:: Copyright (c) 2024-2025 Yegor Bugayenko
+# License:: MIT
+class TestOr < Factbase::Test
+  def test_or_true
+    assert(Factbase::Or.new([Factbase::Always.new([]), Factbase::Never.new([])]).evaluate(fact, [], Factbase.new))
+  end
+
+  def test_or_false
+    refute(Factbase::Or.new([Factbase::Never.new([]), Factbase::Never.new([])]).evaluate(fact, [], Factbase.new))
+  end
+end


### PR DESCRIPTION
This PR refactors the `Factbase::Term` class by creating separate classes for logical terms: `And` and `Or`.

Related to #302