### PR TITLE
feat(#302): create separate classes for 'when' and 'either' terms

### DIFF
--- a/lib/factbase/term.rb
+++ b/lib/factbase/term.rb
@@ -48,6 +48,8 @@ require_relative 'terms/never'
 require_relative 'terms/not'
 require_relative 'terms/or'
 require_relative 'terms/and'
+require_relative 'terms/when'
+require_relative 'terms/either'
 
 # Term.
 #
@@ -141,7 +143,9 @@ class Factbase::Term
       never: Factbase::Never.new(operands),
       not: Factbase::Not.new(operands),
       or: Factbase::Or.new(operands),
-      and: Factbase::And.new(operands)
+      and: Factbase::And.new(operands),
+      when: Factbase::When.new(operands),
+      either: Factbase::Either.new(operands)
     }
   end
 

--- a/lib/factbase/terms/always.rb
+++ b/lib/factbase/terms/always.rb
@@ -9,7 +9,7 @@ require_relative 'base'
 class Factbase::Always < Factbase::TermBase
   # Constructor.
   # @param [Array] operands Operands
-  def initialize(operands)
+  def initialize(operands = [])
     super()
     @operands = operands
     @op = :always

--- a/lib/factbase/terms/either.rb
+++ b/lib/factbase/terms/either.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2025 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+require_relative 'base'
+
+# Represents a logical "either" term.
+# The term evaluates its operands and returns the first non-nil value.
+class Factbase::Either < Factbase::TermBase
+  # Constructor.
+  # @param [Array] operands Operands
+  def initialize(operands)
+    super()
+    @operands = operands
+    @op = :either
+  end
+
+  # Evaluate term on a fact.
+  # @param [Factbase::Fact] fact The fact
+  # @param [Array<Factbase::Fact>] maps All maps available
+  # @param [Factbase] fb Factbase to use for sub-queries
+  # @return [Object] First operand if not nil, otherwise second operand
+  # @return [Boolean] True if first operand is false OR both are true
+  def evaluate(fact, maps, fb)
+    assert_args(2)
+    v = _values(0, fact, maps, fb)
+    return v unless v.nil?
+    _values(1, fact, maps, fb)
+  end
+end

--- a/lib/factbase/terms/logical.rb
+++ b/lib/factbase/terms/logical.rb
@@ -11,28 +11,6 @@ require_relative '../../factbase'
 # Copyright:: Copyright (c) 2024-2025 Yegor Bugayenko
 # License:: MIT
 module Factbase::Logical
-  # Logical implication (IF...THEN)
-  # @param [Factbase::Fact] fact The fact
-  # @param [Array<Factbase::Fact>] maps All maps available
-  # @return [Boolean] True if first operand is false OR both are true
-  def when(fact, maps, fb)
-    assert_args(2)
-    a = @operands[0]
-    b = @operands[1]
-    !a.evaluate(fact, maps, fb) || (a.evaluate(fact, maps, fb) && b.evaluate(fact, maps, fb))
-  end
-
-  # Returns the first non-nil value or the second value
-  # @param [Factbase::Fact] fact The fact
-  # @param [Array<Factbase::Fact>] maps All maps available
-  # @return [Object] First operand if not nil, otherwise second operand
-  def either(fact, maps, fb)
-    assert_args(2)
-    v = _values(0, fact, maps, fb)
-    return v unless v.nil?
-    _values(1, fact, maps, fb)
-  end
-
   # Simplifies AND or OR expressions by removing duplicates
   # @return [Factbase::Term] Simplified term
   def and_or_simplify

--- a/lib/factbase/terms/never.rb
+++ b/lib/factbase/terms/never.rb
@@ -8,7 +8,7 @@ require_relative 'base'
 class Factbase::Never < Factbase::TermBase
   # Constructor.
   # @param [Array] operands Operands
-  def initialize(operands)
+  def initialize(operands = [])
     super()
     @operands = operands
     @op = :never

--- a/lib/factbase/terms/when.rb
+++ b/lib/factbase/terms/when.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2025 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+require_relative 'base'
+# The 'when' class represents a conditional term in the Factbase.
+# It evaluates the operands based on a logical "when" operation.
+class Factbase::When < Factbase::TermBase
+  # Constructor.
+  # @param [Array] operands Operands
+  def initialize(operands)
+    super()
+    @operands = operands
+    @op = :when
+  end
+
+  # Evaluate term on a fact.
+  # @param [Factbase::Fact] fact The fact
+  # @param [Array<Factbase::Fact>] maps All maps available
+  # @param [Factbase] fb Factbase to use for sub-queries
+  # @return [Boolean] True if first operand is false OR both are true
+  def evaluate(fact, maps, fb)
+    assert_args(2)
+    a = @operands[0]
+    b = @operands[1]
+    !a.evaluate(fact, maps, fb) || (a.evaluate(fact, maps, fb) && b.evaluate(fact, maps, fb))
+  end
+end

--- a/test/factbase/terms/test_either.rb
+++ b/test/factbase/terms/test_either.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2025 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+require_relative '../../test__helper'
+require_relative '../../../lib/factbase/term'
+require_relative '../../../lib/factbase/terms/either'
+
+# Test for the 'either' term.
+# Author:: Volodya Lombrozo (volodya.lombrozo@gmail.com)
+# Copyright:: Copyright (c) 2024-2025 Yegor Bugayenko
+# License:: MIT
+class TestEither < Factbase::Test
+  def test_either_first_nil
+    t = Factbase::Either.new([nil, Factbase::Always.new])
+    assert_equal([true], t.evaluate(fact, [], Factbase.new))
+  end
+
+  def test_either_first_not_nil
+    t = Factbase::Either.new([Factbase::Never.new, Factbase::Always.new])
+    assert_equal([false], t.evaluate(fact, [], Factbase.new))
+  end
+end

--- a/test/factbase/terms/test_when.rb
+++ b/test/factbase/terms/test_when.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2025 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+require_relative '../../test__helper'
+require_relative '../../../lib/factbase/term'
+require_relative '../../../lib/factbase/terms/when'
+
+# Test for the 'when' term.
+# Author:: Volodya Lombrozo (volodya.lombrozo@gmail.com)
+# Copyright:: Copyright (c) 2024-2025 Yegor Bugayenko
+# License:: MIT
+class TestWhen < Factbase::Test
+  def test_when_parametrized
+    [
+      [Factbase::Always.new, Factbase::Always.new, true],
+      [Factbase::Never.new,  Factbase::Always.new, true],
+      [Factbase::Never.new,  Factbase::Never.new,  true],
+      [Factbase::Always.new, Factbase::Never.new,  false]
+    ].each do |first, second, should_pass|
+      t = Factbase::When.new([first, second])
+      if should_pass
+        assert(t.evaluate(fact, [], Factbase.new))
+      else
+        refute(t.evaluate(fact, [], Factbase.new))
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR refactors the `Factbase` implementation by creating individual classes for each term, such as `When` and `Either`, improving code organization and readability.

Related to #302