### PR TITLE
feat(#302): move 'first' and 'count'  terms into individual classes

### DIFF
--- a/lib/factbase/term.rb
+++ b/lib/factbase/term.rb
@@ -50,6 +50,8 @@ require_relative 'terms/or'
 require_relative 'terms/and'
 require_relative 'terms/when'
 require_relative 'terms/either'
+require_relative 'terms/count'
+require_relative 'terms/first'
 
 # Term.
 #
@@ -145,7 +147,9 @@ class Factbase::Term
       or: Factbase::Or.new(operands),
       and: Factbase::And.new(operands),
       when: Factbase::When.new(operands),
-      either: Factbase::Either.new(operands)
+      either: Factbase::Either.new(operands),
+      count: Factbase::Count.new(operands),
+      first: Factbase::First.new(operands)
     }
   end
 

--- a/lib/factbase/terms/aggregates.rb
+++ b/lib/factbase/terms/aggregates.rb
@@ -21,10 +21,6 @@ module Factbase::Aggregates
     _best(maps) { |v, b| v > b }
   end
 
-  def count(_fact, maps, _fb)
-    maps.size
-  end
-
   def nth(_fact, maps, _fb)
     assert_args(2)
     pos = @operands[0]
@@ -34,15 +30,6 @@ module Factbase::Aggregates
     m = maps[pos]
     return nil if m.nil?
     m[k.to_s]
-  end
-
-  def first(_fact, maps, _fb)
-    assert_args(1)
-    k = @operands[0]
-    raise "A symbol is expected, but #{k} provided" unless k.is_a?(Symbol)
-    first = maps[0]
-    return nil if first.nil?
-    first[k.to_s]
   end
 
   def sum(_fact, maps, _fb)

--- a/lib/factbase/terms/count.rb
+++ b/lib/factbase/terms/count.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2025 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+require_relative 'base'
+# The 'count' term is used to perform a count operation on a set of maps.
+class Factbase::Count < Factbase::TermBase
+  # Constructor.
+  # @param [Array] operands Operands
+  def initialize(operands)
+    super()
+    @operands = operands
+    @op = :count
+  end
+
+  # Evaluate term on a fact.
+  # @param [Factbase::Fact] _fact The fact
+  # @param [Array<Factbase::Fact>] maps All maps available
+  # @param [Factbase] _fb Factbase to use for sub-queries
+  # @return [Integer] The count of maps
+  def evaluate(_fact, maps, _fb)
+    maps.size
+  end
+end

--- a/lib/factbase/terms/first.rb
+++ b/lib/factbase/terms/first.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2025 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+require_relative 'base'
+# The 'first' term is used to retrieve the value of a specified key from the first map in a set of maps.
+class Factbase::First < Factbase::TermBase
+  # Constructor.
+  # @param [Array] operands Operands
+  def initialize(operands)
+    super()
+    @operands = operands
+    @op = :first
+  end
+
+  # Evaluate term on a fact.
+  # @param [Factbase::Fact] _fact The fact
+  # @param [Array<Factbase::Fact>] maps All maps available
+  # @param [Factbase] _fb Factbase to use for sub-queries
+  # @return [Object] The value of the specified key from the first map
+  def evaluate(_fact, maps, _fb)
+    assert_args(1)
+    k = @operands[0]
+    raise "A symbol is expected, but #{k} provided" unless k.is_a?(Symbol)
+    first = maps[0]
+    return nil if first.nil?
+    first[k.to_s]
+  end
+end

--- a/test/factbase/terms/test_count.rb
+++ b/test/factbase/terms/test_count.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2025 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+require_relative '../../test__helper'
+require_relative '../../../lib/factbase/term'
+require_relative '../../../lib/factbase/terms/count'
+
+# Test for 'count' term.
+# Author:: Vlodya Lombrozo (volodya.lombrozo@gmail.com)
+# Copyright:: Copyright (c) 2024-2025 Yegor Bugayenko
+# License:: MIT
+class TestCount < Factbase::Test
+  def test_count_several
+    t = Factbase::Count.new([])
+    res = t.evaluate(fact, { 'first' => 1, 'second' => 2 }, Factbase.new)
+    assert_equal(2, res)
+  end
+
+  def test_count_emptyseveral
+    t = Factbase::Count.new([])
+    res = t.evaluate(fact, {}, Factbase.new)
+    assert_equal(0, res)
+  end
+end

--- a/test/factbase/terms/test_first.rb
+++ b/test/factbase/terms/test_first.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2025 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+require_relative '../../test__helper'
+require_relative '../../../lib/factbase/term'
+require_relative '../../../lib/factbase/terms/first'
+
+# Test for 'first' term.
+# Author:: Vlodya Lombrozo (volodya.lombrozo@gmail.com)
+# Copyright:: Copyright (c) 2024-2025 Yegor Bugayenko
+# License:: MIT
+class TestFirst < Factbase::Test
+  def test_first_several
+    t = Factbase::First.new([:first])
+    res = t.evaluate(fact, [{ 'first' => 1 }], Factbase.new)
+    assert_equal(1, res)
+  end
+
+  def test_first_absent
+    t = Factbase::First.new([:absent])
+    res = t.evaluate(fact, {}, Factbase.new)
+    assert_nil(res)
+  end
+end


### PR DESCRIPTION
This PR refactors the `Factbase::Term` class by creating separate classes for 'first' and 'count' terms.

Related to #302