### PR TITLE
refactor(#302): create separate classes for nth and sum terms

### DIFF
--- a/lib/factbase/term.rb
+++ b/lib/factbase/term.rb
@@ -52,6 +52,8 @@ require_relative 'terms/when'
 require_relative 'terms/either'
 require_relative 'terms/count'
 require_relative 'terms/first'
+require_relative 'terms/nth'
+require_relative 'terms/sum'
 
 # Term.
 #
@@ -149,7 +151,9 @@ class Factbase::Term
       when: Factbase::When.new(operands),
       either: Factbase::Either.new(operands),
       count: Factbase::Count.new(operands),
-      first: Factbase::First.new(operands)
+      first: Factbase::First.new(operands),
+      nth: Factbase::Nth.new(operands),
+      sum: Factbase::Sum.new(operands)
     }
   end
 

--- a/lib/factbase/terms/aggregates.rb
+++ b/lib/factbase/terms/aggregates.rb
@@ -21,32 +21,6 @@ module Factbase::Aggregates
     _best(maps) { |v, b| v > b }
   end
 
-  def nth(_fact, maps, _fb)
-    assert_args(2)
-    pos = @operands[0]
-    raise "An integer is expected, but #{pos} provided" unless pos.is_a?(Integer)
-    k = @operands[1]
-    raise "A symbol is expected, but #{k} provided" unless k.is_a?(Symbol)
-    m = maps[pos]
-    return nil if m.nil?
-    m[k.to_s]
-  end
-
-  def sum(_fact, maps, _fb)
-    k = @operands[0]
-    raise "A symbol is expected, but '#{k}' provided" unless k.is_a?(Symbol)
-    sum = 0
-    maps.each do |m|
-      vv = m[k.to_s]
-      next if vv.nil?
-      vv = [vv] unless vv.respond_to?(:to_a)
-      vv.each do |v|
-        sum += v
-      end
-    end
-    sum
-  end
-
   def agg(fact, maps, fb)
     assert_args(2)
     selector = @operands[0]

--- a/lib/factbase/terms/nth.rb
+++ b/lib/factbase/terms/nth.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2025 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+require_relative 'base'
+# Represents an 'nth' term in the Factbase.
+# Retrieves the value of a specified key from the nth map.
+class Factbase::Nth < Factbase::TermBase
+  # Constructor.
+  # @param [Array] operands Operands
+  def initialize(operands)
+    super()
+    @operands = operands
+    @op = :nth
+  end
+
+  # Evaluate term on a fact.
+  # @param [Factbase::Fact] _fact The fact
+  # @param [Array<Factbase::Fact>] maps All maps available
+  # @param [Factbase] _fb Factbase to use for sub-queries
+  # @return [Object] The value of the specified key from the nth map
+  def evaluate(_fact, maps, _fb)
+    assert_args(2)
+    pos = @operands[0]
+    raise "An integer is expected, but #{pos} provided" unless pos.is_a?(Integer)
+    k = @operands[1]
+    raise "A symbol is expected, but #{k} provided" unless k.is_a?(Symbol)
+    m = maps[pos]
+    return nil if m.nil?
+    m[k.to_s]
+  end
+end

--- a/lib/factbase/terms/sum.rb
+++ b/lib/factbase/terms/sum.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2025 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+require_relative 'base'
+
+# This class represents a specialized 'sum' term.
+# This term  calculates the sum of values for a specified key.
+class Factbase::Sum < Factbase::TermBase
+  # Constructor.
+  # @param [Array] operands Operands
+  def initialize(operands)
+    super()
+    @operands = operands
+    @op = :sum
+  end
+
+  # Evaluate term on a fact.
+  # @param [Factbase::Fact] _fact The fact
+  # @param [Array<Factbase::Fact>] maps All maps available
+  # @param [Factbase] _fb Factbase to use for sub-queries
+  # @return [Integer] The sum of values for the specified key across all maps
+  def evaluate(_fact, maps, _fb)
+    k = @operands[0]
+    raise "A symbol is expected, but '#{k}' provided" unless k.is_a?(Symbol)
+    sum = 0
+    maps.each do |m|
+      vv = m[k.to_s]
+      next if vv.nil?
+      vv = [vv] unless vv.respond_to?(:to_a)
+      vv.each do |v|
+        sum += v
+      end
+    end
+    sum
+  end
+end

--- a/test/factbase/terms/test_nth.rb
+++ b/test/factbase/terms/test_nth.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2025 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+require_relative '../../test__helper'
+require_relative '../../../lib/factbase/term'
+require_relative '../../../lib/factbase/terms/nth'
+
+# Test for unique term.
+# Author:: Volodya Lombrozo (volodya.lombrozo@gmail.com)
+# Copyright:: Copyright (c) 2024-2025 Yegor Bugayenko
+# License:: MIT
+class TestNth < Factbase::Test
+  def test_nth
+    t = Factbase::Nth.new([1, :number])
+    res = t.evaluate(fact, [{ 'number' => '1' }, { 'number' => %w[2 3] }, { 'number' => '4' }], Factbase.new)
+    assert_equal(%w[2 3], res)
+  end
+
+  def test_nth_out_of_bounds
+    t = Factbase::Nth.new([5, :letter])
+    res = t.evaluate(fact, [{ 'letter' => 'a' }, { 'letter' => 'b' }, { 'letter' => 'c' }], Factbase.new)
+    assert_nil(res)
+  end
+end

--- a/test/factbase/terms/test_sum.rb
+++ b/test/factbase/terms/test_sum.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2025 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+require_relative '../../test__helper'
+require_relative '../../../lib/factbase/term'
+require_relative '../../../lib/factbase/terms/sum'
+
+# Test for unique term.
+# Author:: Volodya Lombrozo (volodya.lombrozo@gmail.com)
+# Copyright:: Copyright (c) 2024-2025 Yegor Bugayenko
+# License:: MIT
+class TestSum < Factbase::Test
+  def test_sum_regular_values
+    t = Factbase::Sum.new([:value])
+    res = t.evaluate(fact, [{ 'value' => 10 }, { 'value' => 20 }, { 'value' => 30 }], Factbase.new)
+    assert_equal(60, res)
+  end
+
+  def test_sum_with_absent_values
+    t = Factbase::Sum.new([:absent])
+    res = t.evaluate(fact, [{ 'value' => 40 }, {}, { 'value' => 50 }], Factbase.new)
+    assert_equal(0, res)
+  end
+end


### PR DESCRIPTION
This PR refactors the `Factbase::Term` class by introducing separate classes for the `nth` and `sum` terms, enhancing code organization and maintainability.

Related to #302