### PR TITLE
fix(#408): resolve `bench_slow_query` timeout issue and add profiling task

### DIFF
--- a/.github/workflows/flamegraph.yml
+++ b/.github/workflows/flamegraph.yml
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2025 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+name: flamegraph
+'on':
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+jobs:
+  flamegraph:
+    timeout-minutes: 15
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.4.7
+          bundler-cache: true
+      - run: bundle config set --global path "$(pwd)/vendor/bundle"
+      - run: bundle install --no-color
+      - run: bundle exec rake 'flamegraph[bench_slow_query]'
+      - name: Verify flamegraph.html was generated
+        run: |
+          if [ ! -f flamegraph.html ]; then
+            echo "Error: flamegraph.html was not created by the profiler."
+            exit 1
+          fi
+          echo "flamegraph.html successfully generated."

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ rdoc/
 vendor/
 .claude/
 .aidy/
+flamegraph.html
+*.flamegraph.html
+stackprof-cpu-myapp.dump

--- a/Gemfile
+++ b/Gemfile
@@ -19,5 +19,6 @@ gem 'rubocop-performance', '~>1.25', require: false
 gem 'rubocop-rake', '~>0.7', require: false
 gem 'simplecov', '~>0.22', require: false
 gem 'simplecov-cobertura', '~>3.0', require: false
+gem 'stackprof', '~>0.2', require: false, platforms: [:ruby]
 gem 'threads', '~>0.4', require: false
 gem 'yard', '~>0.9', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -109,6 +109,7 @@ GEM
       simplecov (~> 0.19)
     simplecov-html (0.13.2)
     simplecov_json_formatter (0.1.4)
+    stackprof (0.2.27)
     stringio (3.1.8)
     tago (0.4.0)
     threads (0.5.0)
@@ -146,6 +147,7 @@ DEPENDENCIES
   rubocop-rake (~> 0.7)
   simplecov (~> 0.22)
   simplecov-cobertura (~> 3.0)
+  stackprof (~> 0.2)
   threads (~> 0.4)
   yard (~> 0.9)
 

--- a/Rakefile
+++ b/Rakefile
@@ -78,3 +78,19 @@ task :benchmark, [:name] do |_t, args|
     end
   end
 end
+
+# Run profiling on a benchmark and generate a flamegraph.
+# To run this task, you need to have stackprof installed.
+# https://github.com/tmm1/stackprof
+# To run profiling for a specific benchmark you can run:
+#   bundle exec rake flamegraph\[bench_slow_query\]
+desc 'Profile a benchmark (e.g., flamegraph[bench_slow_query])'
+task :flamegraph, [:name] do |_t, args|
+  require 'stackprof'
+  bname = args[:name] || 'all'
+  puts "Starting profiling for '#{bname}'..."
+  StackProf.run(mode: :cpu, out: 'stackprof-cpu-myapp.dump', raw: true) do
+    Rake::Task['benchmark'].invoke(bname)
+  end
+  `stackprof --d3-flamegraph stackprof-cpu-myapp.dump > flamegraph.html`
+end

--- a/benchmark/bench_slow_query.rb
+++ b/benchmark/bench_slow_query.rb
@@ -32,7 +32,7 @@ def bench_slow_query(bmk, fb)
     create.call(i + 1)
   end
   bmk.report("(and (eq issue *) (eq repository *) (eq what '*') (eq where '*'))") do
-    Threads.new(Concurrent.processor_count * 20).assert do
+    Threads.new(Concurrent.processor_count * 20, task_timeout: 20, shutdown_timeout: 60).assert do
       # create.call(i + 1) slows down the benchmark significantly
       # with: 16.679675 sec
       # without: 0.212369 sec


### PR DESCRIPTION
This PR fixes the issue with `bench_slow_query` not completing successfully by updating the `Threads` gem and adding a profiling task using `stackprof`.

Fixes #408