### PR TITLE
feat(#302): create separate 'arg' term class for aggregation functionality

### DIFF
--- a/lib/factbase/term.rb
+++ b/lib/factbase/term.rb
@@ -54,6 +54,7 @@ require_relative 'terms/count'
 require_relative 'terms/first'
 require_relative 'terms/nth'
 require_relative 'terms/sum'
+require_relative 'terms/agg'
 
 # Term.
 #
@@ -153,7 +154,8 @@ class Factbase::Term
       count: Factbase::Count.new(operands),
       first: Factbase::First.new(operands),
       nth: Factbase::Nth.new(operands),
-      sum: Factbase::Sum.new(operands)
+      sum: Factbase::Sum.new(operands),
+      agg: Factbase::Agg.new(operands)
     }
   end
 

--- a/lib/factbase/terms/agg.rb
+++ b/lib/factbase/terms/agg.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2025 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+require_relative 'base'
+# The term 'agg' that aggregates.
+class Factbase::Agg < Factbase::TermBase
+  # Constructor.
+  # @param [Array] operands Operands
+  def initialize(operands = [])
+    super()
+    @operands = operands
+    @op = :agg
+  end
+
+  # Evaluate term on a fact.
+  # @param [Factbase::Fact] fact The fact
+  # @param [Array<Factbase::Fact>] maps All maps available
+  # @param [Factbase] fb Factbase to use for sub-queries
+  # @return [Object] The result of evaluation
+  def evaluate(fact, maps, fb)
+    assert_args(2)
+    selector = @operands[0]
+    unless selector.is_a?(Factbase::Term) || selector.is_a?(Factbase::TermBase)
+      raise "A term is expected, but '#{selector}' provided"
+    end
+    term = @operands[1]
+    unless term.is_a?(Factbase::Term) || selector.is_a?(Factbase::TermBase)
+      raise "A term is expected, but '#{term}' provided"
+    end
+    subset = fb.query(selector, maps).each(fb, fact).to_a
+    term.evaluate(nil, subset, fb)
+  end
+end

--- a/lib/factbase/terms/aggregates.rb
+++ b/lib/factbase/terms/aggregates.rb
@@ -21,16 +21,6 @@ module Factbase::Aggregates
     _best(maps) { |v, b| v > b }
   end
 
-  def agg(fact, maps, fb)
-    assert_args(2)
-    selector = @operands[0]
-    raise "A term is expected, but '#{selector}' provided" unless selector.is_a?(Factbase::Term)
-    term = @operands[1]
-    raise "A term is expected, but '#{term}' provided" unless term.is_a?(Factbase::Term)
-    subset = fb.query(selector, maps).each(fb, fact).to_a
-    term.evaluate(nil, subset, fb)
-  end
-
   def empty(fact, maps, fb)
     assert_args(1)
     term = @operands[0]

--- a/test/factbase/terms/test_agg.rb
+++ b/test/factbase/terms/test_agg.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2025 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+require_relative '../../test__helper'
+require_relative '../../../lib/factbase/term'
+require_relative '../../../lib/factbase/terms/agg'
+require_relative '../../../lib/factbase/syntax'
+
+# Test for the 'agg' term.
+# Author:: Volodya Lombrozo (volodya.lombrozo@gmail.com)
+# Copyright:: Copyright (c) 2024-2025 Yegor Bugayenko
+# License:: MIT
+class TestAgg < Factbase::Test
+  def test_aggregation
+    maps = [
+      { 'x' => [1], 'y' => [0], 'z' => [4] },
+      { 'x' => [2], 'y' => [42], 'z' => [3] },
+      { 'x' => [3], 'y' => [42], 'z' => [5] },
+      { 'x' => [4], 'y' => [42], 'z' => [2] },
+      { 'x' => [5], 'y' => [42], 'z' => [1] },
+      { 'x' => [8], 'y' => [0], 'z' => [6] }
+    ]
+    {
+      '(eq x (agg (eq y 42) (min x)))' => '(eq x 2)',
+      '(eq z (agg (eq y 0) (max z)))' => '(eq x 8)',
+      '(eq x (agg (and (eq y 42) (gt z 1)) (max x)))' => '(eq x 4)',
+      '(and (eq x (agg (eq y 42) (min x))) (eq z 3))' => '(eq x 2)',
+      '(eq x (agg (eq y 0) (nth 0 x)))' => '(eq x 1)',
+      '(eq x (agg (eq y 0) (first x)))' => '(eq x 1)',
+      '(agg (eq foo 42) (always))' => '(eq x 1)'
+    }.each do |q, r|
+      t = Factbase::Syntax.new(q).to_term
+      f = maps.find { |m| t.evaluate(fact(m), maps, Factbase.new) }
+      refute_nil(f, "nothing found by: #{q}")
+      assert(Factbase::Syntax.new(r).to_term.evaluate(fact(f), [], Factbase.new))
+    end
+  end
+
+  def test_agg_with_invalid_arguments
+    assert_includes(assert_raises(RuntimeError) do
+      Factbase::Agg.new(%w[foo bar baz]).evaluate(fact({}), [], Factbase.new)
+    end.message, "Too many (3) operands for 'agg' (2 expected)")
+    assert_includes(assert_raises(RuntimeError) do
+      Factbase::Agg.new(['foo', 42]).evaluate(fact({}), [], Factbase.new)
+    end.message, "A term is expected, but 'foo' provided")
+    assert_includes(assert_raises(RuntimeError) do
+      Factbase::Agg.new([Factbase::Term.new(:eq, ['x', 1]), 'bar']).evaluate(fact({}), [], Factbase.new)
+    end.message, "A term is expected, but 'bar' provided")
+  end
+
+  def test_agg_with_correct_arguments
+    t = Factbase::Agg.new([Factbase::Term.new(:eq, [:x, 42]), Factbase::Term.new(:sum, [:y])])
+    maps = [
+      { 'x' => [1], 'y' => [0] },
+      { 'x' => [42], 'y' => [11] },
+      { 'x' => [42], 'y' => [31] },
+      { 'x' => [100], 'y' => [50] }
+    ]
+    assert_equal(42, t.evaluate(fact, maps, Factbase.new))
+  end
+end

--- a/test/factbase/terms/test_aggregates.rb
+++ b/test/factbase/terms/test_aggregates.rb
@@ -12,31 +12,6 @@ require_relative '../../../lib/factbase/syntax'
 # Copyright:: Copyright (c) 2024-2025 Yegor Bugayenko
 # License:: MIT
 class TestAggregates < Factbase::Test
-  def test_aggregation
-    maps = [
-      { 'x' => [1], 'y' => [0], 'z' => [4] },
-      { 'x' => [2], 'y' => [42], 'z' => [3] },
-      { 'x' => [3], 'y' => [42], 'z' => [5] },
-      { 'x' => [4], 'y' => [42], 'z' => [2] },
-      { 'x' => [5], 'y' => [42], 'z' => [1] },
-      { 'x' => [8], 'y' => [0], 'z' => [6] }
-    ]
-    {
-      '(eq x (agg (eq y 42) (min x)))' => '(eq x 2)',
-      '(eq z (agg (eq y 0) (max z)))' => '(eq x 8)',
-      '(eq x (agg (and (eq y 42) (gt z 1)) (max x)))' => '(eq x 4)',
-      '(and (eq x (agg (eq y 42) (min x))) (eq z 3))' => '(eq x 2)',
-      '(eq x (agg (eq y 0) (nth 0 x)))' => '(eq x 1)',
-      '(eq x (agg (eq y 0) (first x)))' => '(eq x 1)',
-      '(agg (eq foo 42) (always))' => '(eq x 1)'
-    }.each do |q, r|
-      t = Factbase::Syntax.new(q).to_term
-      f = maps.find { |m| t.evaluate(fact(m), maps, Factbase.new) }
-      refute_nil(f, "nothing found by: #{q}")
-      assert(Factbase::Syntax.new(r).to_term.evaluate(fact(f), [], Factbase.new))
-    end
-  end
-
   def test_empty
     maps = [
       { 'x' => [1], 'y' => [0], 'z' => [4] },


### PR DESCRIPTION
This PR introduces the `Factbase::Agg` class for aggregation terms.

Related to #302