### PR TITLE
feat(#302): add 'min' term class

### DIFF
--- a/lib/factbase/term.rb
+++ b/lib/factbase/term.rb
@@ -56,6 +56,7 @@ require_relative 'terms/nth'
 require_relative 'terms/sum'
 require_relative 'terms/agg'
 require_relative 'terms/empty'
+require_relative 'terms/min'
 
 # Term.
 #
@@ -157,7 +158,8 @@ class Factbase::Term
       nth: Factbase::Nth.new(operands),
       sum: Factbase::Sum.new(operands),
       agg: Factbase::Agg.new(operands),
-      empty: Factbase::Empty.new(operands)
+      empty: Factbase::Empty.new(operands),
+      min: Factbase::Min.new(operands)
     }
   end
 

--- a/lib/factbase/terms/aggregates.rb
+++ b/lib/factbase/terms/aggregates.rb
@@ -11,12 +11,7 @@ require_relative 'best'
 # Copyright:: Copyright (c) 2024-2025 Yegor Bugayenko
 # License:: MIT
 module Factbase::Aggregates
-  MIN = Factbase::Best.new { |v, b| v < b }
   MAX = Factbase::Best.new { |v, b| v > b }
-  def min(_fact, maps, _fb)
-    assert_args(1)
-    MIN.evaluate(@operands[0], maps)
-  end
 
   def max(_fact, maps, _fb)
     assert_args(1)

--- a/lib/factbase/terms/min.rb
+++ b/lib/factbase/terms/min.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2025 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+require_relative '../../factbase'
+require_relative 'best'
+require_relative 'base'
+
+# The 'min' term.
+# This term calculates the minimum value among the evaluated operands.
+class Factbase::Min < Factbase::TermBase
+  MIN = Factbase::Best.new { |v, b| v < b }
+
+  # Constructor.
+  # @param [Array] operands Operands
+  def initialize(operands)
+    super()
+    @operands = operands
+    @op = :min
+  end
+
+  # Evaluate term on a fact.
+  # @param [Factbase::Fact] _fact The fact
+  # @param [Array<Factbase::Fact>] maps All maps available
+  # @param [Factbase] _fb Factbase to use for sub-queries
+  # @return [Object] The minimum value among the evaluated operands
+  def evaluate(_fact, maps, _fb)
+    assert_args(1)
+    MIN.evaluate(@operands[0], maps)
+  end
+end

--- a/test/factbase/terms/test_min.rb
+++ b/test/factbase/terms/test_min.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2025 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+require_relative '../../test__helper'
+require_relative '../../../lib/factbase/terms/min'
+
+# Test for the 'min' term.
+# Author:: Volodya Lombrozo (volodya.lombrozo@gmail.com)
+# Copyright:: Copyright (c) 2024-2025 Yegor Bugayenko
+# License:: MIT
+class TestMin < Factbase::Test
+  def test_not_enough_args
+    term = Factbase::Min.new([])
+    e =
+      assert_raises(RuntimeError) do
+        term.evaluate(nil, [], nil)
+      end
+    assert_includes(e.message, "Too few (0) operands for 'min' (1 expected)")
+  end
+
+  def test_too_many_args
+    term = Factbase::Min.new([1, 2])
+    e =
+      assert_raises(RuntimeError) do
+        term.evaluate(nil, [], nil)
+      end
+    assert_includes(e.message, "Too many (2) operands for 'min' (1 expected)")
+  end
+
+  def test_min_success
+    term = Factbase::Min.new([:weight])
+    result = term.evaluate(nil, [{ 'weight' => 60 }, { 'weight' => 25 }, { 'weight' => 42 }], nil)
+    assert_equal(25, result)
+  end
+end


### PR DESCRIPTION
This PR introduces a new `Factbase::Min` class, aligning with the design principle of having each term in its own class.

Related to #302