### PR TITLE
#367 Implemented incremental composite indexing for 'unique' term

### DIFF
--- a/benchmark/bench_unique_index.rb
+++ b/benchmark/bench_unique_index.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+def bench_unique_index(bmk, _fb)
+  total = 20_000
+  populate =
+    lambda do |factbase|
+      total.times do |i|
+        factbase.insert.then do |f|
+          f.id = i
+          f.category = %w[A B C D E][i % 5]
+          f.color = %w[red green blue][i % 3]
+        end
+      end
+    end
+  query = '(unique category color)'
+  fb_plain = Factbase.new
+  populate.call(fb_plain)
+  bmk.report("query #{total} facts without unique index") do
+    5.times do
+      fb_plain.query(query).each.to_a
+    end
+  end
+  fb_with_index = Factbase::IndexedFactbase.new(Factbase.new)
+  populate.call(fb_with_index)
+  bmk.report("query #{total} facts with unique index(cold)") do
+    fb_with_index.query(query).each.to_a
+  end
+  bmk.report("query #{total} facts with unique index(warm)") do
+    5.times do
+      fb_with_index.query(query).each.to_a
+    end
+  end
+end

--- a/test/factbase/indexed/test_indexed_unique.rb
+++ b/test/factbase/indexed/test_indexed_unique.rb
@@ -28,7 +28,8 @@ class TestIndexedUnique < Factbase::Test
       ]
     )
     n = term.predict(maps, nil, {})
-    assert_equal(3, n.size)
+    assert_equal(2, n.size)
+    assert_equal([{ 'foo' => [42] }, { 'foo' => [7] }], n.to_a)
   end
 
   def test_predicts_on_unique_with_combinations
@@ -45,5 +46,6 @@ class TestIndexedUnique < Factbase::Test
     )
     n = term.predict(maps, nil, {})
     assert_equal(2, n.size)
+    assert_equal([{ 'foo' => [42], 'bar' => ['a'] }, { 'foo' => [42], 'bar' => ['b'] }], n.to_a)
   end
 end


### PR DESCRIPTION
Closes: https://github.com/yegor256/factbase/issues/367

**Description:**
The previous implementation for unique was naive: it only checked for the presence of keys, ignoring their values. This PR introduces a true value-based index that supports composite uniqueness for multiple operands.

**Performance (20k facts, 5 repeats):** 
#### Before
|               | User (s) | System (s) | Total (s) | Real (s) |
|------------------------------|----------|------------|-----------|----------|
|  without unique index         | 1.459758 | 0.002814   | 1.462572  | 1.465386 |
| with unique index (cold)     | 0.341672 | 0.000990   | 0.342662  | 0.343215 |
| with unique index (warm)     | 1.543960 | 0.007978   | 1.551938  | 1.554257 |

#### After
|               | User (s) | System (s) | Total (s) | Real (s) |
|------------------------------|----------|------------|-----------|----------|
| without unique index         | 1.417975 | 0.002947   | 1.420922  | 1.419839 |
|with unique index (cold)     | 0.037672 | 0.000993   | 0.038665  | 0.038640 |
|with unique index (warm)     | 0.001834 | 0.000000   | 0.001834  | 0.001833 |