### PR TITLE
#491 Add Factbase::Fuzz for random data generation

### DIFF
--- a/lib/fuzz.rb
+++ b/lib/fuzz.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+# Fuzzing generator for Factbase.
+#
+# Author:: Yegor Bugayenko (yegor256@gmail.com)
+# Author:: Philip Belousov (belousovfilip@gmail.com)
+# Copyright:: Copyright (c) 2024-2026 Yegor Bugayenko
+# License:: MIT
+class Factbase::Fuzz
+  LABELS = ['bug', 'enhancement', 'documentation', 'duplicate', 'question', 'good first issue', 'help wanted'].freeze
+  AUTHORS = ['Noah Williams', 'Mason Jones', 'Rocket Man 🚀', 'Иван Иванович', '黒さん', 'Σωκράτης', 'المنطق سي'].freeze
+  TITLES = ['Clean Code', 'Adding more elegance', 'Удаление статики', 'Re de Müller-Lyer', '纯代码', '✨✨✨'].freeze
+  MESSAGES = [
+    'Good point, thanks',
+    'This is not an object, it is a data holder!',
+    'Why is this method static? Please refactor.',
+    'I dont like this name. It is not a noun.',
+    'Please add a unit test for this change.',
+    'NULL is evil, never use it here.',
+    'Pure elegance! Very object-oriented.',
+    'Finally, a clean decorator! Good job.',
+    'Exquisite! No getters, no setters, just behavior.',
+    'This PR makes me happy. It is very elegant.',
+    'Исправь кодировку!',
+    'デザインが悪い (Poor design)',
+    'C’est magnifique! ',
+    'Λογική χωρίς ',
+    'المنطق سيء للغاية',
+    'Este código no es elegante',
+    '❤️❤️❤️'
+  ].freeze
+
+  def initialize
+    @next_num = 0
+    @max_comments = 10
+    raise 'Not enough messages for fuzzing' if MESSAGES.size < @max_comments
+  end
+
+  def self.make(count = 1000)
+    raise "Count must be positive: #{count}" if count.negative?
+    fb = Factbase.new
+    Factbase::Fuzz.new.feed(fb, count)
+    fb
+  end
+
+  def feed(fb, count = 1)
+    raise "Count must be positive: #{count}" if count.negative?
+    count.times do
+      pull_request(fb, @next_num += 1)
+    end
+  end
+
+  private
+
+  def pull_request(fb, idx)
+    f = fb.insert
+    f.number = idx
+    f.ready = rand(2)
+    f.cost = rand(1..32)
+    f.kind = 'pull_request'
+    f.author = AUTHORS.sample
+    f.diff_size = rand(10..5000)
+    f.state = %w[open merged closed].sample
+    f.title = "#{TITLES.sample} in #{LABELS.sample}"
+    f.test_coverage = rand(0.0..100.0).round(2)
+    f.created_at = Time.now - rand(1..(60 * 60 * 24 * 180))
+    MESSAGES.sample(idx % (@max_comments + 1)).each do |comment|
+      f.comments = comment
+    end
+    f
+  end
+end

--- a/test/test_fuzz.rb
+++ b/test/test_fuzz.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+require_relative '../lib/fuzz'
+require_relative 'test__helper'
+
+# Test for Factbase::Fuzz.
+# Author:: Yegor Bugayenko (yegor256@gmail.com)
+# Author:: Philip Belousov (belousovfilip@gmail.com)
+# Copyright:: Copyright (c) 2024-2026 Yegor Bugayenko
+# License:: MIT
+class TestIndexedAnd < Factbase::Test
+  def test_make_generates_default_size
+    fb = Factbase::Fuzz.make
+    assert_equal(1000, fb.query('(always)').to_a.size)
+  end
+
+  def test_make_with_custom_size
+    [0, 150].each do |count|
+      fb = Factbase::Fuzz.make(count)
+      assert_equal(count, fb.query('(always)').to_a.size)
+    end
+  end
+
+  def test_feed_accumulates_facts
+    total = 0
+    fuzz = Factbase::Fuzz.new
+    fb = Factbase::Fuzz.make(0)
+    [0, 50, 100].each do |count|
+      total += count
+      fuzz.feed(fb, count)
+      assert_equal(total, fb.size)
+    end
+  end
+
+  def test_contains_all_required_fields
+    fb = Factbase::Fuzz.make(100)
+    found_empty = false
+    found_filled = false
+    fb.query('(always)').each do |fact|
+      assert_kind_of(Integer, fact.number)
+      assert_kind_of(Integer, fact.cost)
+      assert_kind_of(Integer, fact.diff_size)
+      assert_kind_of(Integer, fact.ready)
+      assert_kind_of(String, fact.kind)
+      assert_kind_of(String, fact.author)
+      assert_kind_of(String, fact.state)
+      assert_kind_of(String, fact.title)
+      assert_kind_of(Float, fact.test_coverage)
+      assert_kind_of(Time, fact.created_at)
+      found_empty = true if fact['comments'].nil?
+      found_filled = true unless fact['comments'].nil?
+    end
+    assert(found_empty, 'Should find at least one fact without comments')
+    assert(found_filled, 'Should find at least one fact with comments')
+  end
+end


### PR DESCRIPTION
New class `Factbase::Fuzz` implemented to generate a `Factbase` with a big amount of random data for testing purposes

The generator populates facts with various types of literals:
**Integer** (number, cost, diff_size)
**Float** (test_coverage)
**String** (author, title,etc.)
**Time** (created_at)
**Accumulative Properties** (comments containing 0 or more string literals)

Closes: [#491](https://github.com/yegor256/factbase/issues/491)