### PR TITLE
#500: Fixed IndexedLt to preserve identity and transaction state

### DIFF
--- a/lib/factbase/indexed/indexed_lt.rb
+++ b/lib/factbase/indexed/indexed_lt.rb
@@ -11,46 +11,39 @@ class Factbase::IndexedLt
   end
 
   def predict(maps, _fb, params)
-    return nil if @idx.nil?
-    return unless @term.operands.first.is_a?(Symbol) && _scalar?(@term.operands[1])
-    prop = @term.operands.first.to_s
-    cache_key = [maps.object_id, @term.operands.first, :sorted]
-    entry = @idx[cache_key]
-    maps_array = maps.to_a
-    if entry.nil?
-      entry = { sorted: [], indexed_count: 0 }
-      @idx[cache_key] = entry
-    end
-    if entry[:indexed_count] < maps_array.size
-      new_pairs = []
-      maps_array[entry[:indexed_count]..].each do |m|
-        values = m[prop]
-        next if values.nil?
-        values.each do |v|
-          new_pairs << [v, m]
-        end
-      end
-      unless new_pairs.empty?
-        entry[:sorted].concat(new_pairs)
-        entry[:sorted].sort_by! { |pair| pair[0] }
-      end
-      entry[:indexed_count] = maps_array.size
-    end
-
-    threshold = @term.operands[1].is_a?(Symbol) ? params[@term.operands[1].to_s]&.first : @term.operands[1]
-    return nil if threshold.nil?
-    i = entry[:sorted].bsearch_index { |pair| pair[0] >= threshold } || entry[:sorted].size
-    result = entry[:sorted][0...i].map { |pair| pair[1] }.uniq
-    if maps.respond_to?(:ensure_copied!)
-      maps & result
-    else
-      (maps & []) | result
-    end
+    op1, op2 = @term.operands
+    return unless op1.is_a?(Symbol) && _scalar?(op2)
+    prop = op1.to_s
+    target = op2.is_a?(Symbol) ? params[op2.to_s]&.first : op2
+    return maps || [] if target.nil?
+    key = [maps.object_id, prop, :facts]
+    @idx[key] ||= { facts: [], count: 0 }
+    entry = @idx[key]
+    _feed(maps.to_a, entry, prop)
+    matched = _search(entry, target)
+    maps.respond_to?(:repack) ? maps.repack(matched) : matched
   end
 
   private
 
   def _scalar?(item)
     item.is_a?(String) || item.is_a?(Time) || item.is_a?(Integer) || item.is_a?(Float) || item.is_a?(Symbol)
+  end
+
+  def _feed(facts, entry, prop)
+    return unless entry[:count] < facts.size
+    facts[entry[:count]..].each do |fact|
+      fact[prop]&.each do |v|
+        entry[:facts] << [v, fact]
+      end
+    end
+    entry[:facts].sort_by! { |pair| pair[0] }
+    entry[:count] = facts.size
+  end
+
+  def _search(entry, target)
+    idx = entry[:facts].bsearch_index { |v, _| v >= target }
+    res = idx.nil? ? entry[:facts] : entry[:facts][0...idx]
+    res.map { |_, f| f }.uniq(&:object_id)
   end
 end

--- a/test/factbase/indexed/test_indexed_factbase.rb
+++ b/test/factbase/indexed/test_indexed_factbase.rb
@@ -356,4 +356,28 @@ class TestIndexedFactbase < Factbase::Test
     end
     assert_equal(2, fb.query('(one scope)').each.to_a.size)
   end
+
+  def test_term_lt_keeps_duplicates
+    fb = Factbase.new
+    fb.insert.scope = 10
+    fb.insert.scope = 10
+    assert_equal(2, fb.query('(lt scope 20)').each.to_a.size)
+  end
+
+  def test_indexed_term_lt_keeps_duplicates
+    fb = Factbase::IndexedFactbase.new(Factbase.new)
+    fb.insert.scope = 10
+    fb.insert.scope = 10
+    assert_equal(2, fb.query('(lt scope 20)').each.to_a.size)
+  end
+
+  def test_indexed_term_lt_keeps_duplicates_in_txn
+    fb = Factbase::IndexedFactbase.new(Factbase.new)
+    fb.txn do |fbt|
+      fbt.insert.scope = 10
+      fbt.insert.scope = 10
+      assert_equal(2, fbt.query('(lt scope 20)').each.to_a.size)
+    end
+    assert_equal(2, fb.query('(lt scope 20)').each.to_a.size)
+  end
 end


### PR DESCRIPTION
Closes: https://github.com/yegor256/factbase/issues/500

## Summary of Changes

This PR fixes a bug where `IndexedLt` failed to correctly find all facts with duplicate property values, especially when inserted inside a transaction.

## Changes
* **Fix**: Updated `IndexedLt` to correctly store and retrieve all facts, even if they share identical property values.
* **Integrity**: Added `uniq(&:object_id)` to the result mapping to ensure distinct facts are preserved while avoiding duplicate entries for a single fact with multiple matching values.
* **Lazy Indexing**: Refactored `_feed` to process only new facts since the last indexing cycle.
* **Decorator Support**: Ensured consistency for `Taped` and `LazyTaped` via the `repack` method.