### PR TITLE
#502: Fixed IndexedAbsent to preserve identity and transaction state

### DIFF
--- a/test/factbase/indexed/test_indexed_absent.rb
+++ b/test/factbase/indexed/test_indexed_absent.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+require_relative '../../test__helper'
+require_relative '../../../lib/factbase'
+require_relative '../../../lib/factbase/term'
+require_relative '../../../lib/factbase/taped'
+require_relative '../../../lib/factbase/lazy_taped'
+require_relative '../../../lib/factbase/indexed/indexed_term'
+
+# Indexed term 'absent' test.
+# Author:: Yegor Bugayenko (yegor256@gmail.com)
+# Author:: Philip Belousov (belousovfilip@gmail.com)
+# Copyright:: Copyright (c) 2024-2026 Yegor Bugayenko
+# License:: MIT
+class TestIndexedAbsent < Factbase::Test
+  def test_predicts_on_absent_with_array
+    _assert_absent { |input| input }
+  end
+
+  def test_predicts_on_absent_with_taped
+    _assert_absent { |input| Factbase::Taped.new(input) }
+  end
+
+  def test_predicts_on_absent_with_lazy_taped
+    _assert_absent { |input| Factbase::LazyTaped.new(input) }
+  end
+
+  def test_predict_decorator_persistence
+    [
+      { input: [{ 'foo' => 42 }], expected: Array },
+      { input: Factbase::Taped.new([{ 'bar' => 42 }]), expected: Factbase::Taped },
+      { input: Factbase::LazyTaped.new([{ 'bar' => 42 }]), expected: Factbase::Taped }
+    ].each do |c|
+      term = Factbase::Term.new(:absent, [:foo])
+      idx = {}
+      term.redress!(Factbase::IndexedTerm, idx:)
+      n = term.predict(c[:input], nil, {})
+      assert_kind_of(c[:expected], n, "Expect #{c[:expected]}, but got #{n.class} for input #{c[:input].class}")
+    end
+  end
+
+  private
+
+  def _assert_absent
+    [
+      { input: [{ 'foo' => [42] }, { 'foo' => [42] }], expected: 0 },
+      { input: [{ 'foo' => [42] }, { 'bar' => [42] }], expected: 1 },
+      { input: [{ 'bar' => [42] }, { 'bar' => [42] }, { 'bar' => [1, 2] }], expected: 3 }
+    ].each do |c|
+      maps = yield(c[:input])
+      idx = {}
+      term = Factbase::Term.new(:absent, [:foo])
+      term.redress!(Factbase::IndexedTerm, idx:)
+      n = term.predict(maps, nil, {})
+      assert_equal(c[:expected], n.size, "Failed on Taped for #{c[:input]}")
+    end
+  end
+end

--- a/test/factbase/indexed/test_indexed_factbase.rb
+++ b/test/factbase/indexed/test_indexed_factbase.rb
@@ -261,6 +261,30 @@ class TestIndexedFactbase < Factbase::Test
     assert_equal(2, fb.query('(exists foo)').each.to_a.size)
   end
 
+  def test_term_absent_keeps_duplicates
+    fb = Factbase.new
+    fb.insert.cost = 10
+    fb.insert.cost = 10
+    assert_equal(2, fb.query('(absent scope)').each.to_a.size)
+  end
+
+  def test_indexed_term_absent_keeps_duplicates
+    fb = Factbase::IndexedFactbase.new(Factbase.new)
+    fb.insert.cost = 10
+    fb.insert.cost = 10
+    assert_equal(2, fb.query('(absent scope)').each.to_a.size)
+  end
+
+  def test_indexed_term_absent_keeps_duplicates_in_txn
+    fb = Factbase::IndexedFactbase.new(Factbase.new)
+    fb.txn do |fbt|
+      fbt.insert.cost = 10
+      fbt.insert.cost = 10
+      assert_equal(2, fbt.query('(absent scope)').each.to_a.size)
+    end
+    assert_equal(2, fb.query('(absent scope)').each.to_a.size)
+  end
+
   def test_term_exists_keeps_duplicates
     fb = Factbase.new
     fb.insert.scope = 1


### PR DESCRIPTION
Closes: https://github.com/yegor256/factbase/issues/502

## Summary of Changes

This PR fixes a bug where `IndexedAbsent` failed to correctly find all facts with duplicate property values, especially when inserted inside a transaction.

## Changes
* **Fix**: Updated `IndexedAbsent` to correctly store and retrieve all facts, even if they share identical property values.
* **Integrity**: Added `uniq(&:object_id)` to the result mapping to ensure distinct facts are preserved while avoiding duplicate entries for a single fact with multiple matching values.
* **Lazy Indexing**: Refactored `_feed` to process only new facts since the last indexing cycle.
* **Decorator Support**: Ensured consistency for `Taped` and `LazyTaped` via the `repack` method.