### PR TITLE
Done puzzles removed

### DIFF
--- a/lib/factbase/lazy_taped_array.rb
+++ b/lib/factbase/lazy_taped_array.rb
@@ -7,10 +7,6 @@ require_relative '../factbase'
 
 class Factbase::LazyTaped
   # Decorator of Array that triggers copy-on-write.
-  # @todo #424:30min Add dedicated unit tests for LazyTapedArray class.
-  #  Currently this class is tested indirectly through LazyTaped tests.
-  #  We should add explicit tests for all public methods including each, [],
-  #  to_a, any?, <<, and uniq! to ensure proper copy-on-write behavior.
   class LazyTapedArray
     # Creates a new lazy array wrapper.
     # @param origin [Array] The original array to wrap

--- a/lib/factbase/lazy_taped_hash.rb
+++ b/lib/factbase/lazy_taped_hash.rb
@@ -8,10 +8,6 @@ require_relative 'lazy_taped_array'
 
 class Factbase::LazyTaped
   # Decorator of Hash that triggers copy-on-write.
-  # @todo #424:30min Add dedicated unit tests for LazyTapedHash class.
-  #  Currently this class is tested indirectly through LazyTaped tests.
-  #  We should add explicit tests for all public methods including keys, map,
-  #  bracket access, bracket assignment, and the copy-on-write behavior.
   class LazyTapedHash
     # Creates a new LazyTapedHash decorator.
     # @param origin [Hash] The original hash being wrapped (not yet copied)

--- a/test/factbase/indexed/test_indexed_term.rb
+++ b/test/factbase/indexed/test_indexed_term.rb
@@ -13,10 +13,6 @@ require_relative '../../../lib/factbase/indexed/indexed_term'
 # Author:: Yegor Bugayenko (yegor256@gmail.com)
 # Copyright:: Copyright (c) 2024-2026 Yegor Bugayenko
 # License:: MIT
-# @todo #363:30min Introduce new test for indexed 'absent' term. We've moved the logic for prediction
-#  'absent' term from IndexedTerm class to a separated IndexedAbsent class. But for some reason there's
-#  no test for the term in this TestIndexedTerm. Let's introduce it and move to a separated test class like
-#  it's done with TestIndexedOne.
 class TestIndexedTerm < Factbase::Test
   def test_predicts_on_others
     term = Factbase::Term.new(:boom, [])


### PR DESCRIPTION
Closes: https://github.com/yegor256/factbase/issues/378

https://github.com/yegor256/factbase/issues/378  puzzle removed (already implemented in https://github.com/yegor256/factbase/issues/502)

> @todo #363:30min Introduce new test for indexed 'absent' term. We've moved the logic for prediction
> 'absent' term from IndexedTerm class to a separated IndexedAbsent class. But for some reason there's
> no test for the term in this TestIndexedTerm. Let's introduce it and move to a separated test class like
> it's done with TestIndexedOne.

https://github.com/yegor256/factbase/issues/445  puzzle removed (already implemented in https://github.com/yegor256/factbase/pull/513)
> @todo #424:30min Add dedicated unit tests for LazyTapedArray class.
> Currently this class is tested indirectly through LazyTaped tests.
> We should add explicit tests for all public methods including each, [],
> to_a, any?, <<, and uniq! to ensure proper copy-on-write behavior.

https://github.com/yegor256/factbase/issues/446 puzzle removed (already implemented in https://github.com/yegor256/factbase/pull/511)
> @todo #424:30min Add dedicated unit tests for LazyTapedHash class.
> Currently this class is tested indirectly through LazyTaped tests.
> We should add explicit tests for all public methods including keys, map,
> bracket access, bracket assignment, and the copy-on-write behavior.