### PR TITLE
#245: refactored benchmark with strict data isolation

### DIFF
--- a/benchmark/bench_txns.rb
+++ b/benchmark/bench_txns.rb
@@ -9,35 +9,46 @@ require_relative '../lib/factbase'
 # bundle exec rake benchmark\[bench_txns\]
 def bench_txns(bmk, _fb)
   sizes = [50_000, 100_000]
+  repeats = 100
+  feed =
+    lambda do |fb, size|
+      size.times { |i| fb.insert.foo = i }
+      fb
+    end
   sizes.each do |size|
-    fb = Factbase.new
-    size.times { |i| fb.insert.foo = i }
-    bmk.report("#{size} facts: read-only txn (no copy needed)") do
-      100.times do
-        fb.txn do |fbt|
-          fbt.query('(always)').each.to_a.size
-        end
+    fb_read_plain = feed.call(Factbase.new, size)
+    bmk.report("#{size} facts: plain read (no txn)") do
+      repeats.times { fb_read_plain.query('(always)').each.to_a.size }
+    end
+    fb_read_txn = feed.call(Factbase.new, size)
+    bmk.report("#{size} facts: read-only txn (no copy)") do
+      repeats.times do
+        fb_read_txn.txn { |fbt| fbt.query('(always)').each.to_a.size }
       end
     end
-    bmk.report("#{size} facts: rollback txn (no copy needed)") do
-      100.times do
-        fb.txn do |fbt|
-          fbt.query('(always)').each.to_a
-          raise Factbase::Rollback
-        end
-      end
+    fb_ins_plain = feed.call(Factbase.new, size)
+    bmk.report("#{size} facts: plain insert (no txn)") do
+      repeats.times { fb_ins_plain.insert.bar = 999 }
     end
+    fb_ins_txn = feed.call(Factbase.new, size)
     bmk.report("#{size} facts: insert in txn (copy triggered)") do
-      100.times do
-        fb.txn do |fbt|
+      repeats.times do
+        fb_ins_txn.txn do |fbt|
           fbt.insert.bar = 999
           raise Factbase::Rollback
         end
       end
     end
+    fb_mod_plain = feed.call(Factbase.new, size)
+    bmk.report("#{size} facts: plain modify (no txn)") do
+      repeats.times do
+        fb_mod_plain.query('(eq foo 0)').each { |f| f.bar = 1 }
+      end
+    end
+    fb_mod_txn = feed.call(Factbase.new, size)
     bmk.report("#{size} facts: modify in txn (copy triggered)") do
-      100.times do
-        fb.txn do |fbt|
+      repeats.times do
+        fb_mod_txn.txn do |fbt|
           fbt.query('(eq foo 0)').each { |f| f.bar = 1 }
           raise Factbase::Rollback
         end


### PR DESCRIPTION

**Problem Diagnosis: Slow Transactions ( https://github.com/yegor256/factbase/issues/245 )**

As reported in https://github.com/yegor256/factbase/issues/245 transactions (especially those that "touch nothing" or are rolled back) are performing significantly slower than expected—taking seconds instead of milliseconds on factbases with 50K+ facts. 

To resolve this, we need a reliable diagnostic tool that isolates the overhead of the transactional layer from raw database operations.

**Comparison: Plain vs. Transactional**
The benchmark now compares raw database operations (Plain) against Transactions side-by-side:
Plain vs Read-only Txn: Shows the overhead of starting a transaction that changes nothing.
Plain vs Modifying Txn: Shows the cost of the Copy-on-Write mechanism.


**Report Example**
```

                                                                  user     system      total        real
50000 facts: plain read (no txn)                               5.801491   0.010958   5.812449 (  5.804682)
50000 facts: read-only txn (no copy)                           7.479274   0.015987   7.495261 (  7.489444)
50000 facts: plain insert (no txn)                             0.001963   0.000000   0.001963 (  0.001960)
50000 facts: insert in txn (copy triggered)                    4.366376   0.008991   4.375367 (  4.373404)
50000 facts: plain modify (no txn)                            32.027878   0.025957  32.053835 ( 32.051601)
50000 facts: modify in txn (copy triggered)                   40.450713   0.062953  40.513666 ( 40.532146)
100000 facts: plain read (no txn)                             12.761953   0.013000  12.774953 ( 12.774308)
100000 facts: read-only txn (no copy)                         15.116491   0.022823  15.139314 ( 15.228389)
100000 facts: plain insert (no txn)                            0.001472   0.000000   0.001472 (  0.001476)
100000 facts: insert in txn (copy triggered)                   8.356195   0.009959   8.366154 (  8.390576)
100000 facts: plain modify (no txn)                           64.280469   0.045956  64.326425 ( 64.383804)
100000 facts: modify in txn (copy triggered)                  81.055174   0.062981  81.118155 ( 81.161666)
```