### PR TITLE
#518: Strict Lint/Debugger for p, pp, puts

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -48,4 +48,13 @@ Security/MarshalLoad:
   Enabled: false
 Layout/MultilineAssignmentLayout:
   Enabled: true
+Lint/Debugger:
+  Enabled: true
+  inherit_mode:
+    merge:
+      - DebuggerMethods
+  DebuggerMethods:
+    - p
+    - pp
+    - puts
 require: []

--- a/Rakefile
+++ b/Rakefile
@@ -88,7 +88,7 @@ desc 'Profile a benchmark (e.g., flamegraph[bench_slow_query])'
 task :flamegraph, [:name] do |_t, args|
   require 'stackprof'
   bname = args[:name] || 'all'
-  puts "Starting profiling for '#{bname}'..."
+  puts "Starting profiling for '#{bname}'..." # rubocop:disable Lint/Debugger
   StackProf.run(mode: :cpu, out: 'stackprof-cpu-myapp.dump', raw: true) do
     Rake::Task['benchmark'].invoke(bname)
   end

--- a/lib/factbase/terms/traced.rb
+++ b/lib/factbase/terms/traced.rb
@@ -27,7 +27,7 @@ class Factbase::Traced < Factbase::TermBase
     t = @operands[0]
     raise "A term is expected, but '#{t}' provided" unless t.is_a?(Factbase::Term)
     r = t.evaluate(fact, maps, fb)
-    puts "#{self} -> #{r}"
+    puts "#{self} -> #{r}" # rubocop:disable Lint/Debugger
     r
   end
 end

--- a/test/factbase/terms/test_unique.rb
+++ b/test/factbase/terms/test_unique.rb
@@ -18,7 +18,6 @@ class TestUnique < Factbase::Test
     assert(t.evaluate(fact('foo' => 41), [], Factbase.new))
     refute(t.evaluate(fact('foo' => 41), [], Factbase.new))
     assert(t.evaluate(fact('foo' => 1), [], Factbase.new))
-    p t
   end
 
   def test_unique_with_multiple_arguments


### PR DESCRIPTION
Closes: https://github.com/yegor256/factbase/issues/518

I've updated the RuboCop configuration to treat standard output methods
(p, pp, puts) as debugger calls. This will prevent accidental
leakages of debug information into the production logs.

<img width="1814" height="336" alt="Screenshot from 2026-02-20 18-59-01" src="https://github.com/user-attachments/assets/5c464a45-bb17-41f5-af6b-16591e3fff8c" />
