### PR TITLE
#245: Make inserts lazy in transactions

### DIFF
--- a/benchmark/bench_txns.rb
+++ b/benchmark/bench_txns.rb
@@ -31,7 +31,7 @@ def bench_txns(bmk, _fb)
       repeats.times { fb_ins_plain.insert.bar = 999 }
     end
     fb_ins_txn = feed.call(Factbase.new, size)
-    bmk.report("#{size} facts: insert in txn (copy triggered)") do
+    bmk.report("#{size} facts: insert in txn (no copy triggered)") do
       repeats.times do
         fb_ins_txn.txn do |fbt|
           fbt.insert.bar = 999

--- a/lib/factbase.rb
+++ b/lib/factbase.rb
@@ -181,7 +181,6 @@ class Factbase
     end
     seen = {}.compare_by_identity
     garbage = {}.compare_by_identity
-    pairs = taped.pairs
     taped.deleted.each do |oid|
       original = @maps.find { |m| m.object_id == oid }
       next if original.nil?
@@ -200,7 +199,8 @@ class Factbase
       b = taped.find_by_object_id(oid)
       next if b.nil?
       next if seen.key?(b)
-      garbage[pairs[b]] = true
+      original = taped.source_of(b)
+      garbage[original] = true if original
       @maps << b
       churn.append(0, 0, 1)
     end

--- a/lib/factbase/lazy_taped.rb
+++ b/lib/factbase/lazy_taped.rb
@@ -11,23 +11,23 @@ require_relative 'lazy_taped_hash'
 class Factbase::LazyTaped
   def initialize(origin)
     @origin = origin
+    @staged = []
     @copied = false
-    @maps = nil
-    @pairs = nil
-    @inverted_pairs = nil
+    @copies = {}.compare_by_identity
     @inserted = []
     @deleted = []
     @added = []
   end
 
-  # Returns a hash mapping copied maps to their originals.
-  # This is used during transaction commit to identify which original facts
-  # were modified, allowing the factbase to update the correct entries.
-  def pairs
-    return {} unless @pairs
-    result = {}.compare_by_identity
-    @pairs.each { |copied, original| result[copied] = original }
-    result
+  # Returns the original map this copy was derived from.
+  # Returns nil if the base hasn't been copied yet or if the fact is new.
+  def source_of(copy)
+    return nil unless @copied
+    @copies.key(copy)
+  end
+
+  def copied?
+    @copied
   end
 
   # Returns the unique object IDs of maps that were inserted (newly created).
@@ -51,101 +51,104 @@ class Factbase::LazyTaped
   end
 
   def find_by_object_id(oid)
-    (@maps || @origin).find { |m| m.object_id == oid }
+    r = @staged.find { |m| m.object_id == oid }
+    r = @origin.find { |m| m.object_id == oid } if r.nil? && !copied?
+    r
   end
 
   def size
-    (@maps || @origin).size
+    copied? ? @staged.size : (@origin.size + @staged.size)
   end
 
   def empty?
-    (@maps || @origin).empty?
+    copied? ? @staged.empty? : (@origin.empty? && @staged.empty?)
   end
 
   def <<(map)
-    ensure_copied!
-    @maps << map
+    @staged << map
+    _track(map, map)
     @inserted.append(map.object_id)
   end
 
   def each
     return to_enum(__method__) unless block_given?
-    if @copied
-      @maps.each do |m|
-        yield Factbase::Taped::TapedHash.new(m, @added)
+    st_size = @staged.size
+    orig_size = @origin.size
+    unless copied?
+      orig_size.times do |i|
+        m = @origin[i]
+        yield _tape(m) unless m.nil?
       end
-    else
-      @origin.each do |m|
-        yield LazyTapedHash.new(m, self, @added)
-      end
+    end
+    st_size.times do |i|
+      m = @staged[i]
+      yield _tape(m) unless m.nil?
     end
   end
 
   def delete_if
     ensure_copied!
-    @maps.delete_if do |m|
+    @staged.delete_if do |m|
       r = yield m
-      @deleted.append(@pairs[m].object_id) if r
+      @deleted.append(source_of(m).object_id) if r
       r
     end
   end
 
   def to_a
-    (@maps || @origin).to_a
+    (copied? ? @staged : (@origin + @staged)).to_a
   end
 
   def repack(other)
     ensure_copied!
-    copied = other.map { |o| @inverted_pairs[o] || o }
+    copied = other.map { |o| @copies[o] || o }
     Factbase::Taped.new(copied, inserted: @inserted, deleted: @deleted, added: @added)
   end
 
   def &(other)
-    if other == [] || (@maps || @origin).empty?
-      return Factbase::Taped.new([], inserted: @inserted, deleted: @deleted, added: @added)
-    end
-    join(other, &:&)
+    return Factbase::Taped.new([], inserted: @inserted, deleted: @deleted, added: @added) if other == []
+    return Factbase::Taped.new([], inserted: @inserted, deleted: @deleted, added: @added) if empty?
+    _join(other, &:&)
   end
 
   def |(other)
     return Factbase::Taped.new(to_a, inserted: @inserted, deleted: @deleted, added: @added) if other == []
-    if (@maps || @origin).empty?
-      return Factbase::Taped.new(other, inserted: @inserted, deleted: @deleted, added: @added)
-    end
-    join(other, &:|)
+    return Factbase::Taped.new(other, inserted: @inserted, deleted: @deleted, added: @added) if empty?
+    _join(other, &:|)
   end
 
   def ensure_copied!
-    return if @copied
-    @pairs = {}.compare_by_identity
-    @inverted_pairs = {}.compare_by_identity
-    @maps =
-      @origin.map do |m|
-        n = m.transform_values(&:dup)
-        @pairs[n] = m
-        @inverted_pairs[m] = n
-        n
-      end
+    return if copied?
+    @origin.each do |o|
+      c = o.transform_values(&:dup)
+      _track(c, o)
+      @staged << c
+    end
     @copied = true
   end
 
   def get_copied_map(original_map)
     ensure_copied!
-    @maps.find { |m| @pairs[m].equal?(original_map) }
+    @copies[original_map] || original_map
   end
 
   private
 
-  def join(other)
+  def _join(other)
     ensure_copied!
-    n = yield (@maps || @origin).to_a, other.to_a
+    n = yield to_a, other.to_a
     raise 'Cannot join with another Taped' if other.respond_to?(:inserted)
     raise 'Can only join with array' unless other.is_a?(Array)
-    Factbase::Taped.new(
-      n,
-      inserted: @inserted,
-      deleted: @deleted,
-      added: @added
-    )
+    Factbase::Taped.new(n, inserted: @inserted, deleted: @deleted, added: @added)
+  end
+
+  def _track(copy, original)
+    @copies[original] = copy
+  end
+
+  def _tape(map)
+    return LazyTapedHash.new(map, self, @added) unless copied?
+    copy = @copies[map] || map
+    Factbase::Taped::TapedHash.new(copy, @added)
   end
 end

--- a/test/test_factbase.rb
+++ b/test/test_factbase.rb
@@ -500,4 +500,21 @@ class TestFactbase < Factbase::Test
       assert_equal("Can't find 'bar' attribute out of [foo]", ex.message)
     end
   end
+
+  def test_each_snapshot_safety
+    fb = Factbase.new
+    (1..10).each { |i| fb.insert.id = i }
+    seen = []
+    fb.txn do |fbt|
+      fbt.query('(always)').each do |f|
+        seen << f.id
+        fbt.query("(eq id #{f.id - 1})").delete!
+        fbt.insert.id = 99
+        fbt.query("(eq id #{f.id})").delete!
+      end
+      assert_equal((1..10).to_a, seen)
+      assert_equal(10, fb.size)
+      assert_equal(10, fbt.query('(eq id 99)').each.to_a.size)
+    end
+  end
 end


### PR DESCRIPTION
Closes: https://github.com/yegor256/factbase/issues/245

### Summary
This PR addresses #245 by implementing a truly lazy copy-on-write mechanism in `Factbase::LazyTaped`. Previously, starting a transaction on a large Factbase (e.g., 100K+ facts) was expensive because it triggered a full duplication of the data immediately upon the first insertion.

### Changes
*   **No initial copy**: Starting a transaction and adding facts (`<<`) now only stages new data in a temporary buffer without touching or duplicating the original collection.
*   **Copy-on-Update**: The full copy of existing facts is now deferred and only triggered if an *existing* fact is modified or deleted.
*   **Fast Rollback**: Transactions that only append facts are now nearly instantaneous to roll back, as no heavy duplication of the base ever occurs.
*   **Optimization**: Refactored internal identity mapping to use a single `@copies` hash, reducing overhead during transaction commits.

### Benchmark
```
-------------------------------------------------------------------------------------------------
                                              |          Branch         |      Impact (> 1.45x) 
----------------------------------------------|-------------------------|------------------------
Benchmark Name                                | master     | current    | speedup    | slowdown  
-------------------------------------------------------------------------------------------------
50000 facts: plain insert                     | 0.001438   | 0.001585   | -          | -         
50000 facts: insert in txn                    | 4.112343   | 0.004521   | 909.61x    | -         
100000 facts: plain insert                    | 0.001449   | 0.001500   | -          | -         
100000 facts: insert in txn                   | 8.862536   | 0.002753   | 3219.23x   | -         
```       