### PR TITLE
519: Switch to bitmask-based indexing for multi_and_eq

### DIFF
--- a/lib/factbase/indexed/indexed_and.rb
+++ b/lib/factbase/indexed/indexed_and.rb
@@ -3,54 +3,33 @@
 # SPDX-FileCopyrightText: Copyright (c) 2024-2026 Yegor Bugayenko
 # SPDX-License-Identifier: MIT
 
+require_relative 'indexed_multi_eq_mask'
+
 # Indexed term 'and'.
 class Factbase::IndexedAnd
-  def initialize(term, idx)
+  def initialize(term, idx, mask_size)
     @term = term
     @idx = idx
+    @mask_size = mask_size
   end
 
   def predict(maps, fb, params)
     return nil if @idx.nil?
-    key = [maps.object_id, @term.operands.first, @term.op]
     r = nil
-    if @term.operands.all? { |o| o.op == :eq } && @term.operands.size > 1 \
-      && @term.operands.all? { |o| o.operands.first.is_a?(Symbol) && _scalar?(o.operands[1]) }
-      props = @term.operands.map { |o| o.operands.first }.sort
-      key = [maps.object_id, props, :multi_and_eq]
-      entry = @idx[key]
-      maps_array = maps.to_a
-      if entry.nil?
-        entry = { index: {}, indexed_count: 0 }
-        @idx[key] = entry
-      end
-      if entry[:indexed_count] < maps_array.size
-        maps_array[entry[:indexed_count]..].each do |m|
-          _all_tuples(m, props).each do |t|
-            entry[:index][t] ||= []
-            entry[:index][t] << m
-          end
-        end
-        entry[:indexed_count] = maps_array.size
-      end
-      tuples = Enumerator.product(
-        *@term.operands.sort_by { |o| o.operands.first }.map do |o|
-          if o.operands[1].is_a?(Symbol)
-            params[o.operands[1].to_s] || []
-          else
-            [o.operands[1]]
-          end
-        end
-      )
-      j = tuples.flat_map { |t| entry[:index][t] || [] }.uniq(&:object_id)
-      r = maps.respond_to?(:repack) ? maps.repack(j) : j
+    if _use_multi_eq?
+      buckets_mask = Factbase::IndexedMultiEqMask.new(@term, @idx, @mask_size).mask(maps, params)
+      matches = _filter_by_mask(maps, buckets_mask, @mask_size)
+      r = maps.respond_to?(:repack) ? maps.repack(matches) : matches
     else
+      max_size = maps.size * 0.95
       @term.operands.each do |o|
         n = o.predict(maps, fb, params)
         break if n.nil?
+        next if n.size >= max_size
         if r.nil?
           r = n
-        elsif n.size < r.size * 8 # to skip some obvious matchings
+        else
+          r, n = n, r if r.size > n.size
           ids = n.to_set(&:object_id)
           r = r.select { |f| ids.include?(f.object_id) }
         end
@@ -63,24 +42,27 @@ class Factbase::IndexedAnd
 
   private
 
-  def _scalar?(item)
-    item.is_a?(String) || item.is_a?(Time) || item.is_a?(Integer) || item.is_a?(Float) || item.is_a?(Symbol)
+  def _use_multi_eq?
+    @term.operands.size > 1 && @term.operands.all? do |op|
+      op.op == :eq && op.operands[0].is_a?(Symbol) && _scalar?(op.operands[1])
+    end
   end
 
-  def _all_tuples(fact, props)
-    prop = props.first.to_s
-    tuples = []
-    tuples += (fact[prop] || []).zip
-    if props.size > 1
-      tails = _all_tuples(fact, props[1..])
-      ext = []
-      tuples.each do |t|
-        tails.each do |tail|
-          ext << (t + tail)
-        end
+  def _filter_by_mask(maps, buckets, m_size)
+    return [] if buckets.empty?
+    matches = []
+    buckets.each do |b_idx, mask|
+      offset = b_idx * m_size
+      while mask.positive?
+        abs_idx = offset + (mask & -mask).bit_length - 1
+        matches << maps[abs_idx]
+        mask &= (mask - 1)
       end
-      tuples = ext
     end
-    tuples
+    matches
+  end
+
+  def _scalar?(item)
+    item.is_a?(String) || item.is_a?(Time) || item.is_a?(Integer) || item.is_a?(Float) || item.is_a?(Symbol)
   end
 end

--- a/lib/factbase/indexed/indexed_multi_eq_mask.rb
+++ b/lib/factbase/indexed/indexed_multi_eq_mask.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+# Indexed for multiple 'eq' mask terms.
+#
+# Author:: Yegor Bugayenko (yegor256@gmail.com)
+# Author:: Philip Belousov (belousovfilip@gmail.com)
+# Copyright:: Copyright (c) 2024-2026 Yegor Bugayenko
+# License:: MIT
+class Factbase::IndexedMultiEqMask
+  def initialize(term, idx, mask_size)
+    @term = term
+    @idx = idx
+    @mask_size = mask_size
+  end
+
+  def mask(maps, params)
+    props = @term.operands.map { |o| o.operands.first.to_s }.sort
+    entry = _entry(maps, props)
+    _feed(maps, entry, props)
+    _build_masks(entry, params)
+  end
+
+  private
+
+  def _entry(maps, props)
+    key = [maps.object_id, props, :multi_and_eq_mask]
+    @idx[key] ||= { facts: {}, count: 0 }
+  end
+
+  def _feed(maps, entry, props)
+    offset = entry[:count]
+    return if offset >= maps.size
+    facts = entry[:facts]
+    m_size = @mask_size
+    (offset...maps.size).each do |abs_idx|
+      item = maps[abs_idx]
+      b_idx, bit_pos = abs_idx.divmod(m_size)
+      bit = 1 << bit_pos
+      props.each do |p|
+        item[p]&.each do |v|
+          (facts[[p, v]] ||= {})[b_idx] = (facts[[p, v]][b_idx] || 0) | bit
+        end
+      end
+    end
+    entry[:count] = maps.size
+  end
+
+  def _build_masks(entry, params)
+    facts = entry[:facts]
+    @term.operands.reduce(nil) do |res, op|
+      prop, raw = op.operands
+      val = params.respond_to?(:resolve) ? params.resolve(raw).first : raw
+      cur = facts[[prop.to_s, val]] || {}
+      return {} if cur.empty?
+      next cur if res.nil?
+      matches = {}
+      target, source = res.size < cur.size ? [res, cur] : [cur, res]
+      target.each do |idx, mask|
+        m = mask & (source[idx] || 0)
+        matches[idx] = m unless m.zero?
+      end
+      return {} if matches.empty?
+      matches
+    end || {}
+  end
+end

--- a/lib/factbase/indexed/indexed_term.rb
+++ b/lib/factbase/indexed/indexed_term.rb
@@ -22,6 +22,7 @@ require_relative '../indexed/indexed_unique'
 # Copyright:: Copyright (c) 2024-2026 Yegor Bugayenko
 # License:: MIT
 module Factbase::IndexedTerm
+  MASK_SIZE = 60
   # Reduces the provided list of facts (maps) to a smaller array, if it's possible.
   #
   # NIL must be returned if indexing is prohibited in this case.
@@ -51,7 +52,7 @@ module Factbase::IndexedTerm
       exists: Factbase::IndexedExists.new(self, @idx),
       absent: Factbase::IndexedAbsent.new(self, @idx),
       unique: Factbase::IndexedUnique.new(self, @idx),
-      and: Factbase::IndexedAnd.new(self, @idx),
+      and: Factbase::IndexedAnd.new(self, @idx, MASK_SIZE),
       not: Factbase::IndexedNot.new(self, @idx),
       or: Factbase::IndexedOr.new(self, @idx)
     }

--- a/lib/factbase/taped.rb
+++ b/lib/factbase/taped.rb
@@ -68,6 +68,14 @@ class Factbase::Taped
     @origin.to_a
   end
 
+  def map(&)
+    each.map(&)
+  end
+
+  def [](idx)
+    @origin[idx]
+  end
+
   def repack(other)
     Factbase::Taped.new(other, inserted: @inserted, deleted: @deleted, added: @added)
   end

--- a/lib/factbase/tee.rb
+++ b/lib/factbase/tee.rb
@@ -31,6 +31,11 @@ class Factbase::Tee
       (@upper.is_a?(Hash) ? @upper.keys : @upper.all_properties)
   end
 
+  def resolve(val)
+    return [val] unless val.is_a?(Symbol)
+    self[val.to_s] || []
+  end
+
   others do |*args|
     if args[0].to_s == '[]' && args[1].start_with?('$')
       n = args[1].to_s

--- a/test/factbase/indexed/test_indexed_multi_eq_mask.rb
+++ b/test/factbase/indexed/test_indexed_multi_eq_mask.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+require_relative '../../test__helper'
+require_relative '../../../lib/factbase'
+require_relative '../../../lib/factbase/term'
+require_relative '../../../lib/factbase/taped'
+require_relative '../../../lib/factbase/indexed/indexed_term'
+require_relative '../../../lib/factbase/indexed/indexed_and'
+
+class TestIndexedMultiEqMask < Factbase::Test
+  def test_builds_mask_directly
+    term = Factbase::Term.new(
+      :and,
+      [
+        Factbase::Term.new(:eq, [:color, 'red']),
+        Factbase::Term.new(:eq, [:size, 'big'])
+      ]
+    )
+    idx = {}
+    mask_size = 2
+    term = Factbase::IndexedMultiEqMask.new(term, idx, mask_size)
+    maps = [
+      { 'color' => ['red'], 'size' => ['big'] },
+      { 'color' => ['blue'], 'size' => ['big'] },
+      { 'color' => ['red'], 'size' => ['big'] }
+    ]
+    buckets = term.mask(maps, {})
+    indexes = _indexes_by_mask(buckets, mask_size)
+    assert_equal([0, 2], indexes)
+  end
+
+  private
+
+  def _indexes_by_mask(buckets, m_size)
+    return [] if buckets.empty?
+    matches = []
+    buckets.each do |b_idx, mask|
+      offset = b_idx * m_size
+      while mask.positive?
+        abs_idx = offset + (mask & -mask).bit_length - 1
+        matches << abs_idx
+        mask &= (mask - 1)
+      end
+    end
+    matches.sort!
+  end
+end


### PR DESCRIPTION
https://github.com/yegor256/factbase/issues/519

### Bitmask-based Indexing for `multi_and_eq`

This PR introduces a significant optimization for multi-property equality queries by replacing the expensive Cartesian product indexing with a compact bitmask-based approach.

### 🏗 Architectural Changes

*   **`IndexedMultiEqMask`**: A new indexing strategy that maps property-value pairs to bitmask buckets.
    *   **Performance**: Uses 60-bit integers to stay within Ruby's `Fixnum` limits, avoiding expensive `Bignum` allocations.
    *   **Memory Efficiency**: Stores fact presence as bits, reducing index size from $O(N)$ property maps to $O(N/60)$ bitmask entries.