### PR TITLE
531: Disable code coverage by default

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -20,6 +20,12 @@ end
 
 task default: %i[clean test picks rubocop yard]
 
+def tail(args = ARGV)
+  i = args.index('--')
+  return '' if i.nil? || args[i + 1].nil?
+  args[i..].join(' ')
+end
+
 require 'rake/testtask'
 desc 'Run all unit tests'
 Rake::TestTask.new(:test) do |test|
@@ -28,6 +34,7 @@ Rake::TestTask.new(:test) do |test|
   test.pattern = 'test/**/test_*.rb'
   test.warning = true
   test.verbose = false
+  test.options = tail
 end
 
 desc 'Run them via Ruby, one by one'

--- a/test/test__helper.rb
+++ b/test/test__helper.rb
@@ -7,7 +7,7 @@ $stdout.sync = true
 
 require 'simplecov'
 require 'simplecov-cobertura'
-unless SimpleCov.running || ENV['PICKS']
+unless SimpleCov.running || ENV['PICKS'] || ARGV.include?('--no-cov')
   SimpleCov.command_name('test')
   SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new(
     [
@@ -18,6 +18,7 @@ unless SimpleCov.running || ENV['PICKS']
   SimpleCov.minimum_coverage 95
   SimpleCov.minimum_coverage_by_file 90
   SimpleCov.start do
+    add_filter 'Rakefile'
     add_filter 'test/'
     add_filter 'vendor/'
     add_filter 'target/'

--- a/test/test_rakefile.rb
+++ b/test/test_rakefile.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+# Test for Factbase::Fuzz.
+# Author:: Yegor Bugayenko (yegor256@gmail.com)
+# Author:: Philip Belousov (belousovfilip@gmail.com)
+# Copyright:: Copyright (c) 2024-2026 Yegor Bugayenko
+# License:: MIT
+#
+require 'minitest/autorun'
+
+class TestRakefile < Minitest::Test
+  load File.expand_path('../Rakefile', __dir__)
+
+  def test_tail_with_arguments
+    [
+      { input: %w[-- --no-cov], expected: '-- --no-cov' },
+      { input: %w[-- --no-cov --verbose], expected: '-- --no-cov --verbose' },
+      { input: %w[test -- --no-cov --verbose], expected: '-- --no-cov --verbose' }
+    ].each do |c|
+      assert_equal(c[:expected], tail(c[:input]), c[:input])
+    end
+  end
+
+  def test_tail_without_arguments
+    [
+      { input: %w[], expected: '' },
+      { input: %w[--], expected: '' },
+      { input: %w[no--cov], expected: '' },
+      { input: %w[--no-cov], expected: '' },
+      { input: %w[test --no-cov], expected: '' }
+    ].each do |c|
+      assert_equal(c[:expected], tail(c[:input]), c[:input])
+    end
+  end
+end


### PR DESCRIPTION
https://github.com/yegor256/factbase/issues/531

Added tail method to Rakefile to allow passing custom arguments (like --no-cov) from the command line. 
Included unit tests for the new logic and updated SimpleCov filters.