### PR TITLE
537: Fix and optimize intersection in IndexedAnd

### DIFF
--- a/lib/factbase/indexed/indexed_and.rb
+++ b/lib/factbase/indexed/indexed_and.rb
@@ -51,8 +51,9 @@ class Factbase::IndexedAnd
         if r.nil?
           r = n
         elsif n.size < r.size * 8 # to skip some obvious matchings
-          ids = n.to_set(&:object_id)
-          r = r.select { |f| ids.include?(f.object_id) }
+          small, large = n.size < r.size ? [n.to_a, r.to_a] : [r.to_a, n.to_a]
+          ids = Set.new(small.map(&:object_id))
+          r = large.select { |f| ids.include?(f.object_id) }
         end
         break if r.size < maps.size / 32 # it's already small enough
         break if r.size < 128 # it's obviously already small enough

--- a/test/factbase/indexed/test_indexed_factbase.rb
+++ b/test/factbase/indexed/test_indexed_factbase.rb
@@ -405,6 +405,7 @@ class TestIndexedFactbase < Factbase::Test
     end
     q = '(and (exists cost) (exists scope))'
     assert_equal(total, fb.query(q).each.to_a.size)
+    fb.txn { |fbt| assert_equal(total, fbt.query(q).each.to_a.size) }
   end
 
   def test_term_one_keeps_duplicates


### PR DESCRIPTION
Closes: https://github.com/yegor256/factbase/issues/537
### Description
The `IndexedAnd` optimization (triggered for 128+ facts) fails during transactions because it expects an `Array` but receives a `Factbase::LazyTaped` or `Taped` decorator, causing `NoMethodError: undefined method 'to_set'`.

### Changes
- **Fix**: Added `.to_a` before building `Set` in `IndexedAnd` to support decorators.
- **Performance**: Optimized intersection by building the `Set` index from the **smaller** collection.