### PR TITLE
#562: evaluate first operand only once in When#evaluate

### DIFF
--- a/lib/factbase/terms/when.rb
+++ b/lib/factbase/terms/when.rb
@@ -24,6 +24,7 @@ class Factbase::When < Factbase::TermBase
     assert_args(2)
     a = @operands[0]
     b = @operands[1]
-    !a.evaluate(fact, maps, fb) || (a.evaluate(fact, maps, fb) && b.evaluate(fact, maps, fb))
+    r = a.evaluate(fact, maps, fb)
+    !r || b.evaluate(fact, maps, fb)
   end
 end

--- a/test/factbase/terms/test_when.rb
+++ b/test/factbase/terms/test_when.rb
@@ -27,4 +27,48 @@ class TestWhen < Factbase::Test
       end
     end
   end
+
+  def test_evaluates_first_operand_only_once
+    counter = CountingTerm.new(true)
+    t = Factbase::When.new([counter, Factbase::Always.new])
+    assert(t.evaluate(fact, [], Factbase.new))
+    assert_equal(1, counter.calls)
+  end
+
+  def test_evaluates_first_operand_only_once_when_false
+    counter = CountingTerm.new(false)
+    t = Factbase::When.new([counter, Factbase::Always.new])
+    assert(t.evaluate(fact, [], Factbase.new))
+    assert_equal(1, counter.calls)
+  end
+
+  def test_unique_inside_when_passes_all_facts
+    fb = Factbase.new
+    3.times { fb.insert.x = 1 }
+    assert_equal(3, fb.query('(when (unique x) (eq x 1))').each.to_a.size)
+  end
+
+  def test_unique_inside_when_with_distinct_values
+    fb = Factbase.new
+    [1, 2, 3].each { |v| fb.insert.x = v }
+    assert_equal(1, fb.query('(when (unique x) (eq x 1))').each.to_a.size)
+  end
+
+  # Term that counts how many times it is evaluated.
+  class CountingTerm < Factbase::TermBase
+    attr_reader :calls
+
+    def initialize(result)
+      super()
+      @operands = []
+      @op = :counting
+      @result = result
+      @calls = 0
+    end
+
+    def evaluate(_fact, _maps, _fb)
+      @calls += 1
+      @result
+    end
+  end
 end


### PR DESCRIPTION
@yegor256 — this PR fixes #562.

## Root cause

`Factbase::When#evaluate` (`lib/factbase/terms/when.rb:27`) was structured as
`!a.evaluate(...) || (a.evaluate(...) && b.evaluate(...))`, which evaluates
the first operand twice when it returns `true`. For stateful terms like `unique`
(which records seen values across calls), the second evaluation flips the
result: the first call marks the value as seen and returns `true`, the second
call sees it already in the `Set` and returns `false`. The query then silently
dropped facts it should have kept.

## Fix

Evaluate `a` once and reuse the result:

```ruby
r = a.evaluate(fact, maps, fb)
!r || b.evaluate(fact, maps, fb)
```

Logically identical to the previous expression (`!a || (a && b)` ≡ `!a || b`)
but with the side effect of `a` only running once.

## Tests

`test/factbase/terms/test_when.rb` adds four tests, all failing on master and
passing on this branch:

- `test_evaluates_first_operand_only_once` — covers `a` returning `true`
- `test_evaluates_first_operand_only_once_when_false` — covers `a` returning `false`
- `test_unique_inside_when_passes_all_facts` — the issue's first reproduction
  (`(when (unique x) (eq x 1))` over three duplicate facts → 3 results, not 2)
- `test_unique_inside_when_with_distinct_values` — the issue's second
  reproduction (over `x ∈ {1,2,3}` → 1 result, not 0)

The first two use a tiny `CountingTerm` fixture so the assertion targets the
double-evaluation directly, not just its observable consequence on `unique`.

## CI

All 12 checks green (rake matrix on ubuntu-24.04, macos-15, windows-2022 with
Ruby 3.4, plus actionlint, copyrights, flamegraph, markdown-lint, pdd, reuse,
typos, xcop, yamllint).