### PR TITLE
Add (contains v s) term for substring queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ There are string manipulators:
 * `(concat v1 v2 v3 ...)` — concatenates all `v`
 * `(sprintf v v1 v2 ...)` — creates a string by `v` format with params
 * `(matches v s)` — if any `v` matches the `s` regular expression
+* `(contains v s)` — if any value of `v` contains any value of `s` (substring match)
 
 There are a few terms that return non-boolean values:
 

--- a/lib/factbase/term.rb
+++ b/lib/factbase/term.rb
@@ -12,6 +12,7 @@ require_relative 'terms/prev'
 require_relative 'terms/concat'
 require_relative 'terms/sprintf'
 require_relative 'terms/matches'
+require_relative 'terms/contains'
 require_relative 'terms/traced'
 require_relative 'terms/assert'
 require_relative 'terms/env'
@@ -108,6 +109,7 @@ class Factbase::Term < Factbase::TermBase
       concat: Factbase::Concat.new(operands),
       sprintf: Factbase::Sprintf.new(operands),
       matches: Factbase::Matches.new(operands),
+      contains: Factbase::Contains.new(operands),
       traced: Factbase::Traced.new(operands),
       assert: Factbase::Assert.new(operands),
       env: Factbase::Env.new(operands),

--- a/lib/factbase/terms/contains.rb
+++ b/lib/factbase/terms/contains.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+require_relative 'base'
+require_relative 'compare'
+
+# Represents a 'contains' term in the Factbase.
+# Returns true if any value of the left operand contains any value of the right
+# as a substring. Operates on string values via `String#include?`.
+class Factbase::Contains < Factbase::TermBase
+  # Constructor.
+  # @param [Array] operands Operands
+  def initialize(operands)
+    super()
+    @op = Factbase::Compare.new(:include?, operands)
+  end
+
+  # Evaluate term on a fact.
+  # @param [Factbase::Fact] fact The fact
+  # @param [Array<Factbase::Fact>] maps All maps available
+  # @param [Factbase] fb Factbase to use for sub-queries
+  # @return [Boolean] True if any left value includes any right value
+  def evaluate(fact, maps, fb)
+    @op.evaluate(fact, maps, fb)
+  end
+end

--- a/test/factbase/terms/test_contains.rb
+++ b/test/factbase/terms/test_contains.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+# Test for contains term.
+# License:: MIT
+
+require_relative '../../test__helper'
+require_relative '../../../lib/factbase/term'
+require_relative '../../../lib/factbase/terms/contains'
+
+class TestContains < Factbase::Test
+  def test_string_substring
+    t = Factbase::Contains.new([:foo, 'ell'])
+    assert(t.evaluate(fact('foo' => 'hello'), [], Factbase.new))
+    refute(t.evaluate(fact('foo' => 'world'), [], Factbase.new))
+  end
+
+  def test_multi_value_property
+    t = Factbase::Contains.new([:tags, 'ruby'])
+    assert(t.evaluate(fact('tags' => %w[ruby rails]), [], Factbase.new))
+    refute(t.evaluate(fact('tags' => %w[python go]), [], Factbase.new))
+  end
+
+  def test_via_query_dispatch
+    fb = Factbase.new
+    f = fb.insert
+    f.title = 'Object Thinking'
+    f.title = 'Elegant Objects'
+    found = fb.query("(contains title 'Elegant')").each.to_a
+    assert_equal(1, found.size)
+  end
+end


### PR DESCRIPTION
Adds a `(contains v s)` term that returns true if any value of `v` contains any value of `s` as a substring (delegates to `String#include?`).

Mirrors the existing `(matches v s)` pattern but uses plain substring semantics rather than regex — useful for cases where regex compilation overhead or escaping noise isn't worth it.

- New file: `lib/factbase/terms/contains.rb`
- Wired into `lib/factbase/term.rb`
- Tests in `test/factbase/terms/test_contains.rb` cover string substring, multi-value array property, and end-to-end query dispatch
- README updated under string manipulators

Implementation reuses `Factbase::Compare` with `:include?` to stay consistent with how `Matches` is structured.