### PR TITLE
Add (ends_with v s) term for suffix-match queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ There are string manipulators:
 * `(matches v s)` — if any `v` matches the `s` regular expression
 * `(contains v s)` — if any value of `v` contains any value of `s` (substring match)
 * `(starts_with v s)` — if any `v` starts with `s`
+* `(ends_with v s)` — if any `v` ends with `s`
 
 There are a few terms that return non-boolean values:
 

--- a/lib/factbase/term.rb
+++ b/lib/factbase/term.rb
@@ -14,6 +14,7 @@ require_relative 'terms/sprintf'
 require_relative 'terms/matches'
 require_relative 'terms/contains'
 require_relative 'terms/starts_with'
+require_relative 'terms/ends_with'
 require_relative 'terms/traced'
 require_relative 'terms/assert'
 require_relative 'terms/env'
@@ -112,6 +113,7 @@ class Factbase::Term < Factbase::TermBase
       matches: Factbase::Matches.new(operands),
       contains: Factbase::Contains.new(operands),
       starts_with: Factbase::StartsWith.new(operands),
+      ends_with: Factbase::EndsWith.new(operands),
       traced: Factbase::Traced.new(operands),
       assert: Factbase::Assert.new(operands),
       env: Factbase::Env.new(operands),

--- a/lib/factbase/terms/ends_with.rb
+++ b/lib/factbase/terms/ends_with.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+require_relative 'base'
+require_relative 'compare'
+
+# Represents an 'ends_with' term in the Factbase.
+# Returns true if any value of the left operand ends with any value of the right.
+class Factbase::EndsWith < Factbase::TermBase
+  # Constructor.
+  # @param [Array] operands Operands
+  def initialize(operands)
+    super()
+    @op = Factbase::Compare.new(:end_with?, operands)
+  end
+
+  # Evaluate term on a fact.
+  # @param [Factbase::Fact] fact The fact
+  # @param [Array<Factbase::Fact>] maps All maps available
+  # @param [Factbase] fb Factbase to use for sub-queries
+  # @return [Boolean] True if any left value ends with any right value
+  def evaluate(fact, maps, fb)
+    @op.evaluate(fact, maps, fb)
+  end
+end

--- a/test/factbase/terms/test_ends_with.rb
+++ b/test/factbase/terms/test_ends_with.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+# Test for ends_with term.
+# License:: MIT
+
+require_relative '../../test__helper'
+require_relative '../../../lib/factbase/term'
+require_relative '../../../lib/factbase/terms/ends_with'
+
+class TestEndsWith < Factbase::Test
+  def test_string_suffix_matches
+    t = Factbase::EndsWith.new([:foo, 'llo'])
+    assert(t.evaluate(fact('foo' => 'hello'), [], Factbase.new))
+    refute(t.evaluate(fact('foo' => 'world'), [], Factbase.new))
+  end
+
+  def test_any_value_in_array_matches
+    t = Factbase::EndsWith.new([:tags, 'by'])
+    assert(t.evaluate(fact('tags' => %w[ruby rails]), [], Factbase.new))
+    refute(t.evaluate(fact('tags' => %w[python go]), [], Factbase.new))
+  end
+
+  def test_via_query_dispatch
+    fb = Factbase.new
+    f = fb.insert
+    f.title = 'Object Thinking'
+    f.title = 'Elegant Objects'
+    found = fb.query("(ends_with title 'Objects')").each.to_a
+    assert_equal(1, found.size)
+  end
+end


### PR DESCRIPTION
Adds an `(ends_with v s)` term that returns true if any value of `v` ends with any value of `s` (delegates to `String#end_with?`).

Same pattern as the new `contains` term — substring-level suffix check without regex overhead.

- New file: `lib/factbase/terms/ends_with.rb`
- Wired into `lib/factbase/term.rb`
- Tests in `test/factbase/terms/test_ends_with.rb` cover string suffix, multi-value array property, and end-to-end query dispatch
- README updated under string manipulators