### PR TITLE
Add (starts_with v s) term for prefix-match queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ There are string manipulators:
 * `(sprintf v v1 v2 ...)` — creates a string by `v` format with params
 * `(matches v s)` — if any `v` matches the `s` regular expression
 * `(contains v s)` — if any value of `v` contains any value of `s` (substring match)
+* `(starts_with v s)` — if any `v` starts with `s`
 
 There are a few terms that return non-boolean values:
 

--- a/lib/factbase/term.rb
+++ b/lib/factbase/term.rb
@@ -13,6 +13,7 @@ require_relative 'terms/concat'
 require_relative 'terms/sprintf'
 require_relative 'terms/matches'
 require_relative 'terms/contains'
+require_relative 'terms/starts_with'
 require_relative 'terms/traced'
 require_relative 'terms/assert'
 require_relative 'terms/env'
@@ -110,6 +111,7 @@ class Factbase::Term < Factbase::TermBase
       sprintf: Factbase::Sprintf.new(operands),
       matches: Factbase::Matches.new(operands),
       contains: Factbase::Contains.new(operands),
+      starts_with: Factbase::StartsWith.new(operands),
       traced: Factbase::Traced.new(operands),
       assert: Factbase::Assert.new(operands),
       env: Factbase::Env.new(operands),

--- a/lib/factbase/terms/starts_with.rb
+++ b/lib/factbase/terms/starts_with.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+require_relative 'base'
+require_relative 'compare'
+
+# Represents a 'starts_with' term in the Factbase.
+# Returns true if any value of the left operand starts with any value of the right.
+class Factbase::StartsWith < Factbase::TermBase
+  # Constructor.
+  # @param [Array] operands Operands
+  def initialize(operands)
+    super()
+    @op = Factbase::Compare.new(:start_with?, operands)
+  end
+
+  # Evaluate term on a fact.
+  # @param [Factbase::Fact] fact The fact
+  # @param [Array<Factbase::Fact>] maps All maps available
+  # @param [Factbase] fb Factbase to use for sub-queries
+  # @return [Boolean] True if any left value starts with any right value
+  def evaluate(fact, maps, fb)
+    @op.evaluate(fact, maps, fb)
+  end
+end

--- a/test/factbase/terms/test_starts_with.rb
+++ b/test/factbase/terms/test_starts_with.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+# Test for starts_with term.
+# License:: MIT
+
+require_relative '../../test__helper'
+require_relative '../../../lib/factbase/term'
+require_relative '../../../lib/factbase/terms/starts_with'
+
+class TestStartsWith < Factbase::Test
+  def test_string_prefix_matches
+    t = Factbase::StartsWith.new([:foo, 'hell'])
+    assert(t.evaluate(fact('foo' => 'hello'), [], Factbase.new))
+    refute(t.evaluate(fact('foo' => 'world'), [], Factbase.new))
+  end
+
+  def test_any_value_in_array_matches
+    t = Factbase::StartsWith.new([:tags, 'ru'])
+    assert(t.evaluate(fact('tags' => %w[ruby rails]), [], Factbase.new))
+    refute(t.evaluate(fact('tags' => %w[python go]), [], Factbase.new))
+  end
+
+  def test_via_query_dispatch
+    fb = Factbase.new
+    f = fb.insert
+    f.title = 'Object Thinking'
+    f.title = 'Elegant Objects'
+    found = fb.query("(starts_with title 'Elegant')").each.to_a
+    assert_equal(1, found.size)
+  end
+end


### PR DESCRIPTION
Adds a `(starts_with v s)` term that returns true if any value of `v` starts with any value of `s` (delegates to `String#start_with?`).

Same pattern as `contains` and `ends_with` — substring-level prefix check without regex overhead.

- New file: `lib/factbase/terms/starts_with.rb`
- Wired into `lib/factbase/term.rb`
- Tests in `test/factbase/terms/test_starts_with.rb` cover string prefix, multi-value array property, and end-to-end query dispatch
- README updated under string manipulators