### PR TITLE
Polish: correct ToJSON/ToXML/ToYAML class names in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,7 +290,7 @@ Persistence uses Ruby's
   is Ruby-version-specific and not portable across major Ruby versions or
   platforms, unlike [JSON](https://www.json.org/json-en.html) or
   [Protocol Buffers](https://protobuf.dev/). Output-only decorators
-  `Factbase::ToJson`, `Factbase::ToXml`, and `Factbase::ToYaml` exist but
+  `Factbase::ToJSON`, `Factbase::ToXML`, and `Factbase::ToYAML` exist but
   do not support round-trip import.
 
 `Factbase::IndexedFactbase` lazily builds a hash-based inverted index for


### PR DESCRIPTION
Tiny README fix. The persistence section refers to `Factbase::ToJson`, `Factbase::ToXml`, and `Factbase::ToYaml`, but the actual classes use full-acronym casing:

- `lib/factbase/to_json.rb` → `class Factbase::ToJSON`
- `lib/factbase/to_xml.rb` → `class Factbase::ToXML`
- `lib/factbase/to_yaml.rb` → `class Factbase::ToYAML`

Updated the README so the names match what's actually loadable.