### PR TITLE
#575: parse negative float exponents

### DIFF
--- a/lib/factbase/syntax.rb
+++ b/lib/factbase/syntax.rb
@@ -142,7 +142,7 @@ class Factbase::Syntax
         t[1..-2]
       elsif t.match?(/^(\+|-)?[0-9]+$/)
         t.to_i
-      elsif t.match?(/^(\+|-)?[0-9]+\.[0-9]+(e\+[0-9]+)?$/)
+      elsif t.match?(/^(\+|-)?[0-9]+\.[0-9]+(e(\+|-)[0-9]+)?$/)
         t.to_f
       elsif t.match?(/^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$/)
         Time.parse(t)

--- a/test/factbase/test_syntax.rb
+++ b/test/factbase/test_syntax.rb
@@ -77,6 +77,11 @@ class TestSyntax < Factbase::Test
     end
   end
 
+  def test_parses_negative_exponent_float
+    term = Factbase::Syntax.new('(eq t 1.5e-10)').to_term
+    assert(term.evaluate({ 't' => 1.5e-10 }, [], Factbase.new))
+  end
+
   def test_simple_matching
     m = {
       'foo' => ['Hello, world!'],


### PR DESCRIPTION
﻿Closes #575.

This widens float token parsing so scientific notation accepts either positive or negative exponents, then adds a regression for `(eq t 1.5e-10)`.

Validation:
- `ruby -Ilib -e "require 'factbase/syntax'; term = Factbase::Syntax.new('(eq t 1.5e-10)').to_term; puts term.class"` -> `Factbase::Term`
- `$env:PICKS='1'; ruby -Ilib -Itest test\factbase\test_syntax.rb --name test_parses_negative_exponent_float` -> 1 test, 1 assertion, 0 failures
- `$env:PICKS='1'; ruby -Ilib -Itest test\factbase\test_syntax.rb` -> 13 tests, 194 assertions, 0 failures
- `ruby -c lib\factbase\syntax.rb` -> `Syntax OK`
- `ruby -c test\factbase\test_syntax.rb` -> `Syntax OK`
- `rubocop lib\factbase\syntax.rb test\factbase\test_syntax.rb` -> 2 files inspected, no offenses
- `git diff --check` -> passed
- `git diff --cached -- lib\factbase\syntax.rb test\factbase\test_syntax.rb | gitleaks stdin --no-banner --redact --exit-code 1` -> no leaks found

Duplicate/currentness check:
- #575 is open, unassigned, and labeled `bug`/`help wanted`.
- Searches for open/all PRs matching `575 negative exponent`, `negative exponent`, and `1.5e-10` found no same-scope PR.

Limitation:
- `bundle exec rubocop ...` could not run locally because the bundle is incomplete on this Windows host: Bundler reports missing `psych-5.3.1`/`rdoc-7.1.0`, and `bundle install` fails building `psych` due missing `yaml.h`.
