### PR TITLE
#576: handle invalid matches regexps

### DIFF
--- a/lib/factbase/terms/matches.rb
+++ b/lib/factbase/terms/matches.rb
@@ -14,6 +14,7 @@ class Factbase::Matches < Factbase::TermBase
   def initialize(operands)
     super()
     @operands = operands
+    @regexps = {}
   end
 
   # Evaluate term on a fact.
@@ -29,6 +30,15 @@ class Factbase::Matches < Factbase::TermBase
     re = _values(1, fact, maps, fb)
     raise 'Regexp is nil' if re.nil?
     raise 'Exactly one regexp is expected' unless re.size == 1
-    str[0].to_s.match?(re[0])
+    str[0].to_s.match?(regexp(re[0]))
+  end
+
+  private
+
+  def regexp(pattern)
+    key = pattern.to_s
+    @regexps[key] ||= Regexp.new(key)
+  rescue RegexpError => e
+    raise "Invalid regexp '#{key}': #{e.message}"
   end
 end

--- a/test/factbase/terms/test_matches.rb
+++ b/test/factbase/terms/test_matches.rb
@@ -19,4 +19,26 @@ class TestMatches < Factbase::Test
     assert(t.evaluate(fact('foo' => 'hello 42'), [], Factbase.new))
     refute(t.evaluate(fact('foo' => 42), [], Factbase.new))
   end
+
+  def test_regexp_from_property
+    t = Factbase::Matches.new(%i[foo pattern])
+    assert(t.evaluate(fact('foo' => 'hello', 'pattern' => '^he'), [], Factbase.new))
+    refute(t.evaluate(fact('foo' => 'hello', 'pattern' => '42$'), [], Factbase.new))
+  end
+
+  def test_reuses_compiled_regexp
+    t = Factbase::Matches.new([:foo, '[a-z]+'])
+    assert(t.evaluate(fact('foo' => 'hello'), [], Factbase.new))
+    assert(t.evaluate(fact('foo' => 'world'), [], Factbase.new))
+    assert_equal(['[a-z]+'], t.instance_variable_get(:@regexps).keys)
+  end
+
+  def test_rejects_invalid_regexp
+    t = Factbase::Matches.new([:foo, '[a-'])
+    e =
+      assert_raises(RuntimeError) do
+        t.evaluate(fact('foo' => 'hello'), [], Factbase.new)
+      end
+    assert_includes(e.message, "Invalid regexp '[a-'")
+  end
 end


### PR DESCRIPTION
Fixes #576.

Changes:
- compile `Matches` regexp operands through a cached helper keyed by pattern
- wrap invalid regexp patterns with a contextual `RuntimeError`
- cover literal, property-sourced, cached, and invalid regexp cases

Validation:
- `PICKS=yes mise x ruby@3.3.11 -- bundle _2.6.8_ exec ruby test/factbase/terms/test_matches.rb` -> 4 tests, 11 assertions, 0 failures, 0 errors, 0 skips
- `mise x ruby@3.3.11 -- bundle _2.6.8_ exec rubocop lib/factbase/terms/matches.rb test/factbase/terms/test_matches.rb` -> 2 files inspected, no offenses detected
- `git diff --check` -> passed
- `git diff | gitleaks stdin --no-banner --redact --exit-code 1` -> no leaks found
- `mise x ruby@3.3.11 -- bundle _2.6.8_ exec rake test` -> 516 tests, 29426 assertions, 1 failure, 0 errors, 2 skips; the failure is `TestLogged#test_proper_logging` and was reproduced on clean `master` with `PICKS=yes mise x ruby@3.3.11 -- bundle _2.6.8_ exec ruby test/factbase/test_logged.rb -n test_proper_logging`
