### PR TITLE
#579: wrap sprintf format errors

### DIFF
--- a/lib/factbase/terms/sprintf.rb
+++ b/lib/factbase/terms/sprintf.rb
@@ -24,6 +24,14 @@ class Factbase::Sprintf < Factbase::TermBase
   def evaluate(fact, maps, fb)
     fmt = _values(0, fact, maps, fb)[0]
     ops = (1..(@operands.length - 1)).map { |i| _values(i, fact, maps, fb)&.first }
+    formatted(fmt, ops)
+  end
+
+  private
+
+  def formatted(fmt, ops)
     format(*([fmt] + ops))
+  rescue ArgumentError => e
+    raise "Cannot format #{ops.inspect} with '#{fmt}' in (sprintf ...): #{e.message}"
   end
 end

--- a/test/factbase/terms/test_sprintf.rb
+++ b/test/factbase/terms/test_sprintf.rb
@@ -17,4 +17,24 @@ class TestSprintf < Factbase::Test
     t = Factbase::Sprintf.new(['hi, %s!', 'Jeff'])
     assert_equal('hi, Jeff!', t.evaluate(fact, [], Factbase.new))
   end
+
+  def test_rejects_invalid_format_operand
+    t = Factbase::Sprintf.new(['%d', 'hello'])
+    e =
+      assert_raises(RuntimeError) do
+        t.evaluate(fact, [], Factbase.new)
+      end
+    assert_includes(e.message, "Cannot format [\"hello\"] with '%d' in (sprintf ...):")
+    assert_includes(e.message, 'invalid value for Integer')
+  end
+
+  def test_rejects_missing_format_operand
+    t = Factbase::Sprintf.new(['%s %s', 'hello'])
+    e =
+      assert_raises(RuntimeError) do
+        t.evaluate(fact, [], Factbase.new)
+      end
+    assert_includes(e.message, "Cannot format [\"hello\"] with '%s %s' in (sprintf ...):")
+    assert_includes(e.message, 'too few arguments')
+  end
 end


### PR DESCRIPTION
Closes #579

Summary:
- wrap `Kernel#format` `ArgumentError` failures from `(sprintf ...)` with the term, format string, operands, and original message
- add regressions for an invalid numeric operand and too few format arguments

Validation:
- `PICKS=yes mise x ruby@3.3.11 -- bundle _2.6.8_ exec ruby test/factbase/terms/test_sprintf.rb` -> `3 tests, 11 assertions, 0 failures, 0 errors, 0 skips`
- `mise x ruby@3.3.11 -- bundle _2.6.8_ exec rubocop lib/factbase/terms/sprintf.rb test/factbase/terms/test_sprintf.rb` -> `2 files inspected, no offenses detected`
- `git diff --check` -> passed
- `git diff | gitleaks stdin --no-banner --redact --exit-code 1` -> no leaks found

Full-suite limitation:
- `mise x ruby@3.3.11 -- bundle _2.6.8_ exec rake test` reached `515 tests, 29428 assertions, 1 failures, 0 errors, 2 skips`; the only failure was `TestLogged#test_proper_logging`, the same unrelated logging assertion failure previously reproduced on clean `master` with this Ruby/Bundler toolchain.
