### PR TITLE
#577: wrap to_time parse errors

### DIFF
--- a/lib/factbase/terms/to_time.rb
+++ b/lib/factbase/terms/to_time.rb
@@ -23,6 +23,14 @@ class Factbase::ToTime < Factbase::TermBase
     assert_args(1)
     vv = _values(0, fact, maps, fb)
     return nil if vv.nil?
-    Time.parse(vv[0].to_s)
+    parse(vv[0])
+  end
+
+  private
+
+  def parse(value)
+    Time.parse(value.to_s)
+  rescue ArgumentError => e
+    raise "Cannot parse '#{value}' as Time in (to_time ...): #{e.message}"
   end
 end

--- a/test/factbase/terms/test_to_time.rb
+++ b/test/factbase/terms/test_to_time.rb
@@ -16,4 +16,24 @@ class TestToTime < Factbase::Test
     t = Factbase::ToTime.new([%w[2023-01-01 hello]])
     assert_equal('Time', t.evaluate(fact, [], Factbase.new).class.to_s)
   end
+
+  def test_rejects_unparseable_value
+    t = Factbase::ToTime.new(['hello'])
+    e =
+      assert_raises(RuntimeError) do
+        t.evaluate(fact, [], Factbase.new)
+      end
+    assert_includes(e.message, "Cannot parse 'hello' as Time in (to_time ...):")
+    assert_includes(e.message, 'no time information')
+  end
+
+  def test_rejects_out_of_range_value
+    t = Factbase::ToTime.new(['2024-13-45'])
+    e =
+      assert_raises(RuntimeError) do
+        t.evaluate(fact, [], Factbase.new)
+      end
+    assert_includes(e.message, "Cannot parse '2024-13-45' as Time in (to_time ...):")
+    assert_includes(e.message, 'argument out of range')
+  end
 end

--- a/test/factbase/terms/test_to_time.rb
+++ b/test/factbase/terms/test_to_time.rb
@@ -17,7 +17,7 @@ class TestToTime < Factbase::Test
     assert_equal('Time', t.evaluate(fact, [], Factbase.new).class.to_s)
   end
 
-  def test_rejects_unparseable_value
+  def test_rejects_unparsable_value
     t = Factbase::ToTime.new(['hello'])
     e =
       assert_raises(RuntimeError) do


### PR DESCRIPTION
Closes #577

Summary:
- wrap `Time.parse` `ArgumentError` failures from `(to_time ...)` with the term, offending value, and original message
- add regressions for an unparseable string and an out-of-range date

Validation:
- `PICKS=yes mise x ruby@3.3.11 -- bundle _2.6.8_ exec ruby test/factbase/terms/test_to_time.rb` -> `3 tests, 11 assertions, 0 failures, 0 errors, 0 skips`
- `mise x ruby@3.3.11 -- bundle _2.6.8_ exec rubocop lib/factbase/terms/to_time.rb test/factbase/terms/test_to_time.rb` -> `2 files inspected, no offenses detected`
- `git diff --check` -> passed
- `git diff | gitleaks stdin --no-banner --redact --exit-code 1` -> no leaks found

Full-suite limitation:
- `mise x ruby@3.3.11 -- bundle _2.6.8_ exec rake test` reached `515 tests, 29428 assertions, 1 failures, 0 errors, 2 skips`; the only failure was `TestLogged#test_proper_logging`, the same unrelated logging assertion failure observed during the adjacent factbase validation passes with this Ruby/Bundler toolchain.
