### PR TITLE
#578: wrap compare argument errors

### DIFF
--- a/lib/factbase/terms/compare.rb
+++ b/lib/factbase/terms/compare.rb
@@ -31,8 +31,23 @@ class Factbase::Compare < Factbase::TermBase
       l = l.floor if l.is_a?(Time) && @op == :==
       rights.any? do |r|
         r = r.floor if r.is_a?(Time) && @op == :==
-        l.send(@op, r)
+        _compare(l, r)
       end
     end
+  end
+
+  private
+
+  # Compare values with a contextual error if Ruby rejects the operands.
+  # @param [Object] left Left value
+  # @param [Object] right Right value
+  # @return [Boolean] The result of the comparison
+  def _compare(left, right)
+    left.send(@op, right)
+  rescue ArgumentError => e
+    raise(
+      "Cannot compare #{left.inspect} (#{left.class}) " \
+      "with #{right.inspect} (#{right.class}) using (compare #{@op}): #{e.message}"
+    )
   end
 end

--- a/test/factbase/terms/test_compare.rb
+++ b/test/factbase/terms/test_compare.rb
@@ -18,4 +18,20 @@ class TestCompare < Factbase::Test
     t = Factbase::Compare.new(:<, [4, 2])
     refute(t.evaluate(fact, [], Factbase.new), 'Expected 2 < 4 to be true')
   end
+
+  def test_wraps_incompatible_type_comparison
+    t = Factbase::Compare.new(:>, [42, 'hello'])
+    e = assert_raises(RuntimeError) { t.evaluate(fact, [], Factbase.new) }
+    assert_includes(e.message, 'Cannot compare 42 (Integer) with "hello" (String)')
+    assert_includes(e.message, 'using (compare >)')
+    assert_includes(e.message, 'comparison of Integer with String failed')
+  end
+
+  def test_wraps_incompatible_time_comparison
+    t = Factbase::Compare.new(:<, [Time.utc(2024, 1, 1), 'yesterday'])
+    e = assert_raises(RuntimeError) { t.evaluate(fact, [], Factbase.new) }
+    assert_includes(e.message, 'Time')
+    assert_includes(e.message, '"yesterday" (String)')
+    assert_includes(e.message, 'comparison of Time with String failed')
+  end
 end


### PR DESCRIPTION
Closes #578

Summary:
- wrap `Compare` `ArgumentError` failures with the operator, operand values/classes, and original message
- add regressions for integer/string and time/string ordering comparisons

Validation:
- `PICKS=yes BUNDLE_PATH=vendor/bundle bundle _2.6.8_ exec ruby test/factbase/terms/test_compare.rb` -> `4 tests, 16 assertions, 0 failures, 0 errors, 0 skips`
- `BUNDLE_PATH=vendor/bundle bundle _2.6.8_ exec rubocop lib/factbase/terms/compare.rb test/factbase/terms/test_compare.rb` -> `2 files inspected, no offenses detected`
- `git diff --check` -> passed
- `git diff | gitleaks stdin --no-banner --redact --exit-code 1` -> no leaks found
- `BUNDLE_PATH=vendor/bundle bundle _2.6.8_ exec rake test` -> `515 tests, 29436 assertions, 0 failures, 0 errors, 2 skips`

Environment note:
- Local validation used Ruby 3.3.8 with Bundler 2.6.8 on Kali; CI will cover the repository Ruby 3.4 matrix.
