### PR TITLE
docs: warn that `import` deserializes with `Marshal.load` (#106)

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,7 +293,13 @@ Persistence uses Ruby's
   platforms, unlike [JSON](https://www.json.org/json-en.html) or
   [Protocol Buffers](https://protobuf.dev/). Output-only decorators
   `Factbase::ToJSON`, `Factbase::ToXML`, and `Factbase::ToYAML` exist but
-  do not support round-trip import.
+  do not support round-trip import. Because `import` calls `Marshal.load`
+  on the incoming bytes, the input must come from a source the caller
+  trusts; a `Marshal` stream crafted by an attacker can execute arbitrary
+  code in the calling process, so factbase blobs received over the
+  network or read from a user-supplied path should be authenticated
+  out-of-band before being imported, as described in the
+  [Ruby security notes](https://docs.ruby-lang.org/en/3.3/security_rdoc.html#label-Marshal.load).
 
 `Factbase::IndexedFactbase` lazily builds a hash-based inverted index for
   equality queries, keyed by array `object_id`, property name, and

--- a/lib/factbase.rb
+++ b/lib/factbase.rb
@@ -233,6 +233,16 @@ class Factbase
   # This method supports both the original format (Array of maps) and
   # the IndexedFactbase format (Hash with :maps and :idx keys).
   #
+  # SECURITY: the input must come from a source you trust, because it is
+  # deserialized with +Marshal.load+. Loading a +Marshal+ stream crafted
+  # by an attacker can execute arbitrary code in the calling process,
+  # so never call +import+ on bytes received over the network, read from
+  # a user-supplied path, or pulled from any other untrusted channel
+  # without an out-of-band integrity check. See the official Ruby
+  # security notes for +Marshal.load+ at
+  # https://docs.ruby-lang.org/en/3.3/security_rdoc.html#label-Marshal.load
+  # for details.
+  #
   # @param [String] bytes Binary string to import
   def import(bytes)
     raise(StandardError, 'Empty input, cannot load a factbase') if bytes.empty?


### PR DESCRIPTION
Issue #106 reports that `Factbase#import` is dangerous when the input comes from an untrusted source, because the method deserializes the bytes with `Marshal.load`, which can run arbitrary code embedded in a hostile stream. The thread already settled on a long-term plan to swap the persistence format, but neither the method docs nor the README persistence section currently warn callers about the immediate risk, so this change closes that documentation gap as a small first step.

The patch adds a `SECURITY:` block to the YARD docs of `Factbase#import` in `lib/factbase.rb` and extends the persistence paragraph in `README.md` with one sentence linking to the official Ruby `Marshal.load` security note. No code path or public API is changed, so behaviour and serialization format stay identical.

Verified locally with `bundle exec rubocop lib/factbase.rb` (no offenses on the modified file) and `bundle exec ruby -Ilib -Itest test/test_factbase.rb` (35 tests, 860 assertions, 0 failures, 0 errors, 0 skips). The repository-wide RuboCop run reports the same 105 pre-existing offenses on `master`, none of them in the files touched here.

Refs #106.
