### PR TITLE
docs: drop #599 incorrect "thread-safe" parenthetical in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ The values are either atomic literals or non-empty sets of literals.
 It is possible to delete a fact, but impossible to delete a property
 from a fact.
 
-Here is how you use it (it's thread-safe, by the way):
+Here is how you use it (wrap it with `Factbase::SyncFactbase`
+for thread-safe access):
 
 ```ruby
 fb = Factbase.new


### PR DESCRIPTION
The opening example on `README.md:22` told readers the gem is thread-safe in passing, but the architecture section on `README.md:285-287` and the class header on `lib/factbase.rb:78` both state that the bare `Factbase` is not thread-safe and must be wrapped with `Factbase::SyncFactbase` before being shared across threads. A reader following the opening snippet would assume `Factbase.new` is safe to share, miss the `SyncFactbase` decorator the architecture section points at, and hit data races the decorator exists to prevent.

The patch replaces the parenthetical so the opening example agrees with the rest of the document and surfaces the `SyncFactbase` decorator at the very first usage example. Behaviour, public API, and the persisted format are untouched.

Verified locally with `npx markdownlint-cli2 README.md` (0 errors). No code paths changed, so the rake test suite and rubocop runs are unaffected by the diff.

Closes #599
