### PR TITLE
#614: SPDX header placed after require in test_fact.rb

### DIFF
--- a/test/factbase/test_fact.rb
+++ b/test/factbase/test_fact.rb
@@ -1,9 +1,10 @@
 # frozen_string_literal: true
 
-require_relative '../../lib/factbase'
-require_relative '../../lib/factbase/fact'
 # SPDX-FileCopyrightText: Copyright (c) 2024-2026 Yegor Bugayenko
 # SPDX-License-Identifier: MIT
+
+require_relative '../../lib/factbase'
+require_relative '../../lib/factbase/fact'
 
 require_relative '../test__helper'
 


### PR DESCRIPTION

In test/factbase/test_fact.rb, the SPDX-FileCopyrightText and SPDX-License-Identifier headers appear after require_relative statements instead of at the top of the file.