### PR TITLE
#628: Reduce fragility of txn performance degradation test

### DIFF
--- a/test/factbase/test_query.rb
+++ b/test/factbase/test_query.rb
@@ -327,7 +327,7 @@ class TestQuery < Factbase::Test
 
   # This test ensures that the number of objects allocated during a transaction
   def test_txn_performance_degradation
-    max_growth = 5
+    max_growth = 30
     size = 1000
     maps = (0..1000).map { |_i| { 'foo' => [rand(size)], 'bar' => [rand(size)], 'xyz' => [rand(size)] } }
     with_factbases(maps) do |badge, fb|


### PR DESCRIPTION
Increased max_growth tolerance from 5 to 30 to avoid false positives across different Ruby versions and GC states