### PR TITLE
#632: Add test coverage for defn/undef operators

### DIFF
--- a/test/factbase/terms/test_defn.rb
+++ b/test/factbase/terms/test_defn.rb
@@ -2,6 +2,7 @@
 
 require_relative '../../../lib/factbase/term'
 require_relative '../../../lib/factbase/terms/defn'
+require_relative '../../../lib/factbase/terms/undef'
 # SPDX-FileCopyrightText: Copyright (c) 2024-2026 Yegor Bugayenko
 # SPDX-License-Identifier: MIT
 
@@ -12,6 +13,17 @@ require_relative '../../test__helper'
 # Copyright:: Copyright (c) 2024-2026 Yegor Bugayenko
 # License:: MIT
 class TestDefn < Factbase::Test
+  def setup
+    super
+    @defn_name = :_defn_teardown
+    Factbase::Undef.new([@defn_name]).evaluate(fact, [], Factbase.new)
+  end
+
+  def teardown
+    Factbase::Undef.new([@defn_name]).evaluate(fact, [], Factbase.new)
+    super
+  end
+
   def test_defn_simple
     assert(Factbase::Defn.new([:foo, 'self.to_s']).evaluate(fact('foo' => 4), [], Factbase.new))
     assert_equal(
@@ -39,6 +51,40 @@ class TestDefn < Factbase::Test
     t = Factbase::Defn.new([:'some-key', 'self.to_s'])
     assert_raises(StandardError) do
       t.evaluate(fact, [], Factbase.new)
+    end
+  end
+
+  def test_defn_bad_name_with_digits
+    assert_raises(StandardError) do
+      Factbase::Defn.new([:'123abc', 'true']).evaluate(fact, [], Factbase.new)
+    end
+  end
+
+  def test_defn_bad_name_with_caps
+    assert_raises(StandardError) do
+      Factbase::Defn.new([:FooBar, 'true']).evaluate(fact, [], Factbase.new)
+    end
+  end
+
+  def test_defn_eval_arbitrary_code
+    n = :_defn_eval_z
+    Factbase::Undef.new([n]).evaluate(fact, [], Factbase.new)
+    Factbase::Defn.new([n, '42']).evaluate(fact, [], Factbase.new)
+    assert_equal(42, Factbase::Term.new(n, []).evaluate(fact, [], Factbase.new))
+  end
+
+  def test_defn_undef_then_use
+    n = @defn_name
+    Factbase::Defn.new([n, 'true']).evaluate(fact, [], Factbase.new)
+    Factbase::Undef.new([n]).evaluate(fact, [], Factbase.new)
+    assert_raises(RuntimeError) do
+      Factbase::Term.new(n, []).evaluate(fact, [], Factbase.new)
+    end
+  end
+
+  def test_defn_non_symbol_argument
+    assert_raises(ArgumentError) do
+      Factbase::Defn.new(%w[string_name true]).evaluate(fact, [], Factbase.new)
     end
   end
 end

--- a/test/factbase/terms/test_undef.rb
+++ b/test/factbase/terms/test_undef.rb
@@ -19,4 +19,25 @@ class TestUndef < Factbase::Test
     t = Factbase::Undef.new([:hello])
     assert(t.evaluate(fact, [], Factbase.new))
   end
+
+  def test_undef_nonexistent
+    assert(Factbase::Undef.new([:_nonexistent]).evaluate(fact, [], Factbase.new))
+  end
+
+  def test_undef_non_symbol
+    assert_raises(ArgumentError) do
+      Factbase::Undef.new(['string']).evaluate(fact, [], Factbase.new)
+    end
+  end
+
+  def test_undef_defined_then_removed
+    fn = :_undef_query_fn
+    Factbase::Undef.new([fn]).evaluate(fact, [], Factbase.new)
+    Factbase::Defn.new([fn, 'true']).evaluate(fact, [], Factbase.new)
+    assert(Factbase::Term.new(fn, []).evaluate(fact, [], Factbase.new))
+    Factbase::Undef.new([fn]).evaluate(fact, [], Factbase.new)
+    assert_raises(RuntimeError) do
+      Factbase::Term.new(fn, []).evaluate(fact, [], Factbase.new)
+    end
+  end
 end


### PR DESCRIPTION
Add missing test coverage for defn and undef operators:

- defn with bad names (digits, caps)
- defn with non-symbol argument
- defn eval arbitrary Ruby code
- defn then undef then use raises RuntimeError
- undef nonexistent method
- undef with non-symbol argument