### PR TITLE
#633: Add cache invalidation tests for CachedFactbase

### DIFF
--- a/test/factbase/cached/test_cached_factbase.rb
+++ b/test/factbase/cached/test_cached_factbase.rb
@@ -58,4 +58,30 @@ class TestCachedFactbase < Factbase::Test
     f.bar = 42
     assert_nil(fb.query('(agg (not (exists bar)) (max value))').one)
   end
+
+  def test_insert_after_query_returns_new_facts
+    fb = Factbase::CachedFactbase.new(Factbase.new)
+    fb.insert.foo = 1
+    assert_equal(1, fb.query('(always)').each.to_a.size)
+    fb.insert.foo = 2
+    assert_equal(2, fb.query('(always)').each.to_a.size)
+  end
+
+  def test_insert_after_one_returns_new_value
+    fb = Factbase::CachedFactbase.new(Factbase.new)
+    fb.insert.foo = 10
+    assert_equal(10, fb.query('(agg (always) (max foo))').one)
+    fb.insert.foo = 20
+    assert_equal(20, fb.query('(agg (always) (max foo))').one)
+  end
+
+  def test_query_after_txn_sees_new_facts
+    fb = Factbase::CachedFactbase.new(Factbase.new)
+    fb.insert.foo = 1
+    assert_equal(1, fb.query('(always)').each.to_a.size)
+    fb.txn do |fbt|
+      fbt.insert.foo = 2
+    end
+    assert_equal(2, fb.query('(always)').each.to_a.size)
+  end
 end

--- a/test/factbase/cached/test_cached_term.rb
+++ b/test/factbase/cached/test_cached_term.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+require_relative '../../../lib/factbase'
+require_relative '../../../lib/factbase/cached/cached_factbase'
+require_relative '../../test__helper'
+
+# Test for CachedTerm mixing.
+# Author:: Yegor Bugayenko (yegor256@gmail.com)
+# Copyright:: Copyright (c) 2024-2026 Yegor Bugayenko
+# License:: MIT
+class TestCachedTerm < Factbase::Test
+  def test_caches_static_terms
+    cache = {}
+    fb = Factbase::CachedFactbase.new(Factbase.new, cache)
+    fb.insert.foo = 42
+    fb.query('(always)').each.to_a
+    refute_nil(
+      cache.keys.find do |k|
+        k.is_a?(Array) && k.last.include?('always')
+      end, "Expected a cached static term key in #{cache.keys}"
+    )
+  end
+
+  def test_does_not_cache_head
+    cache = {}
+    fb = Factbase::CachedFactbase.new(Factbase.new, cache)
+    fb.insert.foo = 42
+    fb.query('(head 1 (always))').each.to_a
+    head_key = cache.keys.find { |k| k.is_a?(Array) && k.last.include?('(head') }
+    assert_nil(head_key, "Head term should not be cached, but found: #{head_key}")
+  end
+
+  def test_does_not_cache_unique
+    cache = {}
+    fb = Factbase::CachedFactbase.new(Factbase.new, cache)
+    fb.insert.foo = 42
+    fb.insert.foo = 99
+    fb.query('(unique foo)').each.to_a
+    assert_empty(cache.keys.grep(Array))
+  end
+end


### PR DESCRIPTION
Add tests verifying cache invalidation behavior:

- Insert after query returns new facts
- Insert after one() returns updated value
- txn after query sees new facts  
- CachedTerm caches static terms
- CachedTerm does not cache head/unique