### PR TITLE
#640: Add IndexedGte, IndexedLte; fix IndexedAnd/Unique predict

### DIFF
--- a/lib/factbase/indexed/indexed_and.rb
+++ b/lib/factbase/indexed/indexed_and.rb
@@ -45,9 +45,13 @@ class Factbase::IndexedAnd
       j = tuples.flat_map { |t| entry[:index][t] || [] }.uniq(&:object_id)
       r = maps.respond_to?(:repack) ? maps.repack(j) : j
     else
+      fail = false
       @term.operands.each do |o|
         n = o.predict(maps, fb, params)
-        break if n.nil?
+        if n.nil?
+          fail = true
+          break
+        end
         if r.nil?
           r = n
         elsif n.size < r.size * 8
@@ -58,6 +62,7 @@ class Factbase::IndexedAnd
         break if r.size < maps.size / 32
         break if r.size < 128
       end
+      return if fail
     end
     r
   end

--- a/lib/factbase/indexed/indexed_gte.rb
+++ b/lib/factbase/indexed/indexed_gte.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+# Indexed term 'gte'.
+class Factbase::IndexedGte
+  def initialize(term, idx)
+    @term = term
+    @idx = idx
+  end
+
+  def predict(maps, _fb, params)
+    op1, op2 = @term.operands
+    return unless op1.is_a?(Symbol) && _scalar?(op2)
+    prop = op1.to_s
+    target = op2.is_a?(Symbol) ? params[op2.to_s]&.first : op2
+    return maps || [] if target.nil?
+    key = [maps.object_id, prop, :facts]
+    @idx[key] ||= { facts: [], count: 0 }
+    entry = @idx[key]
+    _feed(maps.to_a, entry, prop)
+    matched = _search(entry, target)
+    maps.respond_to?(:repack) ? maps.repack(matched) : matched
+  end
+
+  private
+
+  def _scalar?(item)
+    item.is_a?(String) || item.is_a?(Time) || item.is_a?(Integer) || item.is_a?(Float) || item.is_a?(Symbol)
+  end
+
+  def _feed(facts, entry, prop)
+    return unless entry[:count] < facts.size
+    facts[entry[:count]..].each do |fact|
+      fact[prop]&.each do |v|
+        entry[:facts] << [v, fact]
+      end
+    end
+    entry[:facts].sort_by! { |pair| pair[0] }
+    entry[:count] = facts.size
+  end
+
+  def _search(entry, target)
+    idx = entry[:facts].bsearch_index { |v, _| v >= target }
+    return [] if idx.nil?
+    facts = entry[:facts][idx..].map { |_, f| f }
+    facts.uniq!(&:object_id)
+    facts
+  end
+end

--- a/lib/factbase/indexed/indexed_lte.rb
+++ b/lib/factbase/indexed/indexed_lte.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+# Indexed term 'lte'.
+class Factbase::IndexedLte
+  def initialize(term, idx)
+    @term = term
+    @idx = idx
+  end
+
+  def predict(maps, _fb, params)
+    op1, op2 = @term.operands
+    return unless op1.is_a?(Symbol) && _scalar?(op2)
+    prop = op1.to_s
+    target = op2.is_a?(Symbol) ? params[op2.to_s]&.first : op2
+    return maps || [] if target.nil?
+    key = [maps.object_id, prop, :facts]
+    @idx[key] ||= { facts: [], count: 0 }
+    entry = @idx[key]
+    _feed(maps.to_a, entry, prop)
+    matched = _search(entry, target)
+    maps.respond_to?(:repack) ? maps.repack(matched) : matched
+  end
+
+  private
+
+  def _scalar?(item)
+    item.is_a?(String) || item.is_a?(Time) || item.is_a?(Integer) || item.is_a?(Float) || item.is_a?(Symbol)
+  end
+
+  def _feed(facts, entry, prop)
+    return unless entry[:count] < facts.size
+    facts[entry[:count]..].each do |fact|
+      fact[prop]&.each do |v|
+        entry[:facts] << [v, fact]
+      end
+    end
+    entry[:facts].sort_by! { |pair| pair[0] }
+    entry[:count] = facts.size
+  end
+
+  def _search(entry, target)
+    idx = entry[:facts].bsearch_index { |v, _| v > target }
+    res = idx.nil? ? entry[:facts] : entry[:facts][0...idx]
+    facts = res.map { |_, f| f }
+    facts.uniq!(&:object_id)
+    facts
+  end
+end

--- a/lib/factbase/indexed/indexed_term.rb
+++ b/lib/factbase/indexed/indexed_term.rb
@@ -10,7 +10,9 @@ require_relative '../indexed/indexed_and'
 require_relative '../indexed/indexed_eq'
 require_relative '../indexed/indexed_exists'
 require_relative '../indexed/indexed_gt'
+require_relative '../indexed/indexed_gte'
 require_relative '../indexed/indexed_lt'
+require_relative '../indexed/indexed_lte'
 require_relative '../indexed/indexed_not'
 require_relative '../indexed/indexed_one'
 require_relative '../indexed/indexed_or'
@@ -46,7 +48,9 @@ module Factbase::IndexedTerm
     @indexes = {
       eq: Factbase::IndexedEq.new(self, @idx),
       lt: Factbase::IndexedLt.new(self, @idx),
+      lte: Factbase::IndexedLte.new(self, @idx),
       gt: Factbase::IndexedGt.new(self, @idx),
+      gte: Factbase::IndexedGte.new(self, @idx),
       one: Factbase::IndexedOne.new(self, @idx),
       exists: Factbase::IndexedExists.new(self, @idx),
       absent: Factbase::IndexedAbsent.new(self, @idx),

--- a/lib/factbase/indexed/indexed_unique.rb
+++ b/lib/factbase/indexed/indexed_unique.rb
@@ -10,7 +10,9 @@ class Factbase::IndexedUnique
     @idx = idx
   end
 
-  def predict(maps, _fb, _params)
-    maps
+  # rubocop:disable Elegant/NoNilReturn
+  def predict(_maps, _fb, _params)
+    nil
   end
+  # rubocop:enable Elegant/NoNilReturn
 end


### PR DESCRIPTION
ARCH changes:

1. **IndexedGte/IndexedLte** — new indexed terms for >= and <=, using bsearch on sorted value arrays. Same pattern as IndexedGt/IndexedLt.
2. **IndexedAnd#predict** — return nil when any operand can't be predicted (instead of returning partial result from previous operands). Prevents incorrect early-exit optimization.
3. **IndexedUnique#predict** — return nil (unique is stateful and can't be index-predicted).