### PR TITLE
#601: Syntax#to_tokens fuses identifiers separated by newline or tab

### DIFF
--- a/lib/factbase/syntax.rb
+++ b/lib/factbase/syntax.rb
@@ -99,7 +99,7 @@ class Factbase::Syntax
     list = []
     acc = ''
     quotes = ['\'', '"']
-    spaces = [' ', ')']
+    spaces = [' ', ')', "\n", "\t", "\r"]
     string = false
     comment = false
     @query.to_s.chars.each do |c|

--- a/test/factbase/test_syntax.rb
+++ b/test/factbase/test_syntax.rb
@@ -57,6 +57,14 @@ class TestSyntax < Factbase::Test
     end
   end
 
+  def test_tokenizes_across_newline
+    assert_equal('(eq foo 1)', Factbase::Syntax.new("(eq foo\n1)").to_term.to_s)
+  end
+
+  def test_tokenizes_across_tab
+    assert_equal('(eq foo 1)', Factbase::Syntax.new("(eq\tfoo 1)").to_term.to_s)
+  end
+
   def test_exact_parsing
     [
       '(foo)',


### PR DESCRIPTION
Bug fix for #601.

**Problem:** `Syntax#to_tokens` keeps `spaces = [' ', ')']` for flushing the token accumulator. Tabs and newlines (`\n`, `\t`, `\r`) are skipped by the `case c` branch but never trigger a flush, fusing adjacent identifiers.

For example:
- `(eq foo\n1)` tokenises to `[:open, "eq", "foo1", :close]` instead of `[:open, "eq", "foo", 1, :close]`
- `(eq\tfoo 1)` tokenises to `[:open, "eqfoo", 1, :close]`

**Fix:** Added `\n`, `\t`, `\r` to the `spaces` list.

**Tests:** Added `test_tokenizes_across_newline` and `test_tokenizes_across_tab` regression tests.

Fixes #601
