### PR TITLE
#485: detect useless pre-conditional assignments via test

### DIFF
--- a/test/test_no_useless_conditional_assignment.rb
+++ b/test/test_no_useless_conditional_assignment.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+require 'parser/current'
+require_relative 'test__helper'
+
+# Detects an antipattern that RuboCop's +Lint/UselessAssignment+ misses:
+# a local variable is initialized just before an +if+/+unless+/+case+ that
+# overwrites the variable in every reachable branch, never having read the
+# initial value. See yegor256/factbase#485.
+class TestNoUselessConditionalAssignment < Factbase::Test
+  ROOT = File.expand_path('../lib', __dir__)
+
+  def test_lib_is_free_of_useless_conditional_assignments
+    offenses = []
+    Dir.glob(File.join(ROOT, '**', '*.rb')).each do |path|
+      ast =
+        begin
+          Parser::CurrentRuby.parse(File.read(path))
+        rescue Parser::SyntaxError
+          nil
+        end
+      next if ast.nil?
+      walk(ast) { |seq| scan_sequence(seq.children, path, offenses) }
+    end
+    assert_empty(offenses, format_message(offenses))
+  end
+
+  private
+
+  def format_message(offenses)
+    [
+      "Found #{offenses.size} useless pre-conditional assignment(s):",
+      *offenses.map do |o|
+        "  #{o[:path]}:#{o[:line]}: `#{o[:var]} = ...` is overwritten by the following conditional"
+      end,
+      'See https://github.com/yegor256/factbase/issues/485'
+    ].join("\n")
+  end
+
+  def walk(node, &block)
+    return unless node.is_a?(Parser::AST::Node)
+    yield(node) if node.type == :begin
+    node.children.each { |c| walk(c, &block) }
+  end
+
+  def scan_sequence(stmts, path, offenses)
+    stmts.each_with_index do |stmt, i|
+      next unless stmt.is_a?(Parser::AST::Node) && stmt.type == :lvasgn
+      var, rhs = stmt.children
+      next if rhs.nil?
+      next if reads?(rhs, var)
+      nxt = stmts[i + 1]
+      next unless nxt.is_a?(Parser::AST::Node) && nxt.type == :if
+      cond, tbranch, fbranch = nxt.children
+      next if reads?(cond, var)
+      next unless overwrites_without_reading?(tbranch, var)
+      if fbranch.nil?
+        rest = stmts[(i + 2)..] || []
+        next if rest.any? { |s| reads?(s, var) }
+      else
+        next unless overwrites_without_reading?(fbranch, var)
+      end
+      offenses << { path: path, line: stmt.loc.line, var: var }
+    end
+  end
+
+  # Does the subtree read +var+ as a local variable?
+  def reads?(node, var)
+    return false unless node.is_a?(Parser::AST::Node)
+    return true if node.type == :lvar && node.children[0] == var
+    node.children.any? { |c| reads?(c, var) }
+  end
+
+  # In execution order, does +branch+ assign +var+ before any read of +var+,
+  # with the assignment's right-hand side itself not reading +var+? A +nil+
+  # branch counts as "no assignment".
+  def overwrites_without_reading?(branch, var)
+    return false if branch.nil?
+    stmts = branch.is_a?(Parser::AST::Node) && branch.type == :begin ? branch.children : [branch]
+    stmts.each do |s|
+      next unless s.is_a?(Parser::AST::Node)
+      if s.type == :lvasgn && s.children[0] == var
+        rhs = s.children[1]
+        return false if rhs && reads?(rhs, var)
+        return true
+      end
+      return false if reads?(s, var)
+    end
+    false
+  end
+end


### PR DESCRIPTION
Issue #485 reports that RuboCop's `Lint/UselessAssignment` misses a class of useless writes: a local variable is initialized just before an `if`/`unless`/`case` that overwrites it in every reachable branch without ever reading the initial value. The cop stays silent because, syntactically, the variable is still "read" on the false path when no `else` is present.

This pull request adds a minitest case under `test/` that parses every Ruby file in `lib/` with the `parser` gem (already in the bundle via RuboCop), walks each sequence of statements, and asserts no `lvasgn` matches the shape: cond does not read the variable, the truthy branch overwrites it without reading first, and either both branches overwrite or no later statement reads the initial value. The `lib/` tree is clean today, so the test passes; new regressions will fail it with a file-and-line list and a pointer back to the issue. I spot-checked the detector against the example in the issue body and it reports the expected offense.

Checks run: `bundle exec rake rubocop` (clean), `bundle exec rake yard` (clean), `bundle exec rake test` (529 tests, 1 failure — `TestLogged#test_proper_logging`, which fails the same way on `master` due to a string-truncation expectation and is unrelated to this change), and the new file in isolation under `PICKS=yes`.

Closes #485
