### PR TITLE
Restore eager materialization in IndexedQuery#each (#648)

### DIFF
--- a/lib/factbase/indexed/indexed_query.rb
+++ b/lib/factbase/indexed/indexed_query.rb
@@ -38,7 +38,7 @@ class Factbase::IndexedQuery
   def each(fb = @fb, params = {})
     return to_enum(__method__, fb, params) unless block_given?
     n = 0
-    @origin.each(fb, params) do |f|
+    @origin.each(fb, params).to_a.each do |f|
       yield(Factbase::IndexedFact.new(f, @idx, @fresh))
       n += 1
     end

--- a/test/factbase/indexed/test_indexed_query.rb
+++ b/test/factbase/indexed/test_indexed_query.rb
@@ -201,6 +201,21 @@ class TestIndexedQuery < Factbase::Test
     end
   end
 
+  def test_materializes_before_iterating
+    fb = Factbase::IndexedFactbase.new(Factbase.new)
+    3.times do |i|
+      f = fb.insert
+      f.kind = 'in'
+      f.id = i
+    end
+    created = 0
+    fb.query("(and (eq kind 'in') (empty (eq kind 'out')))").each do |_f|
+      fb.insert.then { |n| n.kind = 'out' }
+      created += 1
+    end
+    assert_equal(3, created)
+  end
+
   def test_deletes_too
     fb = Factbase::IndexedFactbase.new(Factbase.new)
     fb.insert.foo = 1


### PR DESCRIPTION
Fixes #648.

## Problem

Since 0.19.12, `IndexedQuery#each` streamed facts straight from `@origin`, yielding them one by one. Because the yields now interleaved with the origin query's per-fact term evaluation, a caller that inserts facts inside the loop changed which later facts matched. An `(empty ...)` sub-term used as a dedup guard, for example, started seeing the facts that were just inserted — which broke `Fbe.conclude` downstream.

Before 0.19.12, `each` first drained the origin into an array (`a = @origin.each(fb, params).to_a`) and only then yielded each element, making each iteration a stable snapshot.

## Fix

Restore eager materialization: collect `@origin.each(fb, params)` into an array before yielding, so iteration stays a consistent snapshot even when the caller mutates the factbase mid-loop.

## Test

Added `test_materializes_before_iterating`, which reproduces the scenario from the issue (the snippet that prints `3` on 0.19.11 and `1` on 0.19.12). Verified it fails without the fix and passes with it.

https://claude.ai/code/session_01XdpmLXjrvfEVNt95rHcdDj

---
_Generated by [Claude Code](https://claude.ai/code/session_01XdpmLXjrvfEVNt95rHcdDj)_