### PR TITLE
#655: guard against nil in Env#evaluate

### DIFF
--- a/lib/factbase/terms/env.rb
+++ b/lib/factbase/terms/env.rb
@@ -22,7 +22,12 @@ class Factbase::Env < Factbase::TermBase
   # @return [String] The value of the environment variable or the default
   def evaluate(fact, maps, fb)
     assert_args(2)
-    n = _values(0, fact, maps, fb)[0]
-    ENV.fetch(n.upcase) { _values(1, fact, maps, fb)[0] }
+    n = _values(0, fact, maps, fb)
+    return if n.nil?
+    ENV.fetch(n[0].upcase) do
+      d = _values(1, fact, maps, fb)
+      return if d.nil?
+      d[0]
+    end
   end
 end

--- a/test/factbase/terms/test_env.rb
+++ b/test/factbase/terms/test_env.rb
@@ -1,9 +1,10 @@
 # frozen_string_literal: true
 
-require_relative '../../../lib/factbase/term'
-require_relative '../../../lib/factbase/terms/env'
 # SPDX-FileCopyrightText: Copyright (c) 2024-2026 Yegor Bugayenko
 # SPDX-License-Identifier: MIT
+
+require_relative '../../../lib/factbase/term'
+require_relative '../../../lib/factbase/terms/env'
 
 require_relative '../../test__helper'
 
@@ -26,5 +27,15 @@ class TestEnv < Factbase::Test
     ENV.delete('FOO')
     t = Factbase::Env.new(['FOO'])
     assert_raises(StandardError) { t.evaluate(fact, [], Factbase.new) }
+  end
+
+  def test_missing_attr_returns_nil
+    ENV.delete('FOO')
+    assert_nil(Factbase::Env.new([:missing_attr, 'fallback']).evaluate(fact, [], Factbase.new))
+  end
+
+  def test_missing_default_returns_nil
+    ENV.delete('FOO')
+    assert_nil(Factbase::Env.new(%i[missing_attr also_missing]).evaluate(fact, [], Factbase.new))
   end
 end


### PR DESCRIPTION
Closes #655.

Added nil-guards before indexing into `_values` results in `Factbase::Env#evaluate`, matching the pattern used by all other conversion terms (`to_float`, `to_time`, `to_integer`, `to_string`).

Also added two tests:
- `test_missing_attr_returns_nil` — first operand is a sym for a missing attribute
- `test_missing_default_returns_nil` — both operands are missing attributes