### PR TITLE
#656: fix wrong receiver in docstring example

### DIFF
--- a/lib/factbase.rb
+++ b/lib/factbase.rb
@@ -17,7 +17,7 @@ require 'yaml'
 #  f = fb.insert # new fact created
 #  f.name = 'Jeff Lebowski'
 #  f.age = 42
-#  found = f.query('(gt 20 age)').each.to_a[0]
+#  found = fb.query('(gt 20 age)').each.to_a[0]
 #  assert(found.age == 42)
 #
 # Every fact is a key-value hash map. Every value is a non-empty set of values.


### PR DESCRIPTION
Closes #656.

Fixed the class-level docstring example in `lib/factbase.rb:20`: `f.query(...)` → `fb.query(...)`. `f` is a `Factbase::Fact` which has no `query` method — `query` is on `Factbase`.