### PR TITLE
#660: fix nil error message in Check#it when expression is short

### DIFF
--- a/lib/factbase/rules.rb
+++ b/lib/factbase/rules.rb
@@ -122,8 +122,10 @@ class Factbase::Rules
 
     def it(fact, fb)
       return if Factbase::Syntax.new(@expr).to_term.evaluate(fact, [], fb)
-      e = "#{@expr[0..32]}..." if @expr.length > 32
-      raise(ArgumentError, "The fact doesn't match the #{e.inspect} rule: #{fact}")
+      raise(
+        ArgumentError,
+        "The fact doesn't match the #{(@expr.length > 32 ? "#{@expr[0..31]}..." : @expr).inspect} rule: #{fact}"
+      )
     end
   end
 

--- a/test/factbase/test_rules.rb
+++ b/test/factbase/test_rules.rb
@@ -1,10 +1,11 @@
 # frozen_string_literal: true
 
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
 require_relative '../../lib/factbase'
 require_relative '../../lib/factbase/pre'
 require_relative '../../lib/factbase/rules'
-# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Yegor Bugayenko
-# SPDX-License-Identifier: MIT
 
 require_relative '../test__helper'
 
@@ -115,5 +116,26 @@ class TestRules < Factbase::Test
     end
     assert(ok)
     assert_equal(0, fb.query('(eq hello $v)').each(v: 42).to_a.size)
+  end
+
+  def test_error_message_includes_expression
+    f = Factbase::Rules.new(Factbase.new, '(exists foo)').insert
+    ex =
+      assert_raises(StandardError) do
+        f.bar = 42
+      end
+    assert_includes(ex.message, '(exists foo)', 'Error message should include the rule expression')
+    refute_includes(ex.message, 'nil', 'Error message should not contain "nil"')
+  end
+
+  def test_error_message_truncates_long_expression
+    rule = '(and (exists a) (exists b) (exists c) (exists d) (exists e))'
+    assert_operator(rule.length, :>, 32)
+    f = Factbase::Rules.new(Factbase.new, rule).insert
+    assert_includes(
+      assert_raises(StandardError) { f.bar = 42 }.message,
+      '...',
+      'Error message should truncate long expressions'
+    )
   end
 end


### PR DESCRIPTION
Closes #660.

The `if` modifier at `lib/factbase/rules.rb:125` only assigned `e` when `@expr.length > 32`. For shorter expressions, `e` stayed `nil` and the error message showed `nil` instead of the actual rule.

Replaced with a ternary so `e` is always set. Also fixed the truncation boundary from `0..32` (33 chars) to `0..31` (32 chars) so the truncated form fits.

Added two tests:
- `test_error_message_includes_expression` — short rule shows in message
- `test_error_message_truncates_long_expression` — long rule is truncated with `...`