### PR TITLE
#661: rescue ArgumentError in to_float and to_integer like to_time

### DIFF
--- a/lib/factbase/terms/to_float.rb
+++ b/lib/factbase/terms/to_float.rb
@@ -29,8 +29,8 @@ class Factbase::ToFloat < Factbase::TermBase
   private
 
   def to_float(value)
-    Float(value)
-  rescue ArgumentError => e
+    Float(value.to_s)
+  rescue ArgumentError, TypeError => e
     raise(RuntimeError, "Cannot convert '#{value}' to Float in (to_float ...): #{e.message}")
   end
 end

--- a/lib/factbase/terms/to_float.rb
+++ b/lib/factbase/terms/to_float.rb
@@ -23,6 +23,14 @@ class Factbase::ToFloat < Factbase::TermBase
     assert_args(1)
     vv = _values(0, fact, maps, fb)
     return if vv.nil?
-    Float(vv[0])
+    to_float(vv[0])
+  end
+
+  private
+
+  def to_float(value)
+    Float(value)
+  rescue ArgumentError => e
+    raise(RuntimeError, "Cannot convert '#{value}' to Float in (to_float ...): #{e.message}")
   end
 end

--- a/lib/factbase/terms/to_integer.rb
+++ b/lib/factbase/terms/to_integer.rb
@@ -23,14 +23,14 @@ class Factbase::ToInteger < Factbase::TermBase
     assert_args(1)
     vv = _values(0, fact, maps, fb)
     return if vv.nil?
-    to_int(vv[0])
+    to_integer(vv[0])
   end
 
   private
 
-  def to_int(value)
-    Integer(value)
-  rescue ArgumentError => e
+  def to_integer(value)
+    Integer(value.to_s)
+  rescue ArgumentError, TypeError => e
     raise(RuntimeError, "Cannot convert '#{value}' to Integer in (to_integer ...): #{e.message}")
   end
 end

--- a/lib/factbase/terms/to_integer.rb
+++ b/lib/factbase/terms/to_integer.rb
@@ -23,6 +23,14 @@ class Factbase::ToInteger < Factbase::TermBase
     assert_args(1)
     vv = _values(0, fact, maps, fb)
     return if vv.nil?
-    Integer(vv[0])
+    to_int(vv[0])
+  end
+
+  private
+
+  def to_int(value)
+    Integer(value)
+  rescue ArgumentError => e
+    raise(RuntimeError, "Cannot convert '#{value}' to Integer in (to_integer ...): #{e.message}")
   end
 end

--- a/test/factbase/terms/test_to_float.rb
+++ b/test/factbase/terms/test_to_float.rb
@@ -1,9 +1,10 @@
 # frozen_string_literal: true
 
-require_relative '../../../lib/factbase/term'
-require_relative '../../../lib/factbase/terms/to_float'
 # SPDX-FileCopyrightText: Copyright (c) 2024-2026 Yegor Bugayenko
 # SPDX-License-Identifier: MIT
+
+require_relative '../../../lib/factbase/term'
+require_relative '../../../lib/factbase/terms/to_float'
 
 require_relative '../../test__helper'
 
@@ -14,5 +15,13 @@ require_relative '../../test__helper'
 class TestToFloat < Factbase::Test
   def test_to_float
     assert_equal('Float', Factbase::ToFloat.new([[3.14, 'hello']]).evaluate(fact, [], Factbase.new).class.to_s)
+  end
+
+  def test_rejects_invalid_value
+    t = Factbase::ToFloat.new(['abc'])
+    assert_includes(
+      assert_raises(RuntimeError) { t.evaluate(fact, [], Factbase.new) }.message,
+      "Cannot convert 'abc' to Float in (to_float ...):"
+    )
   end
 end

--- a/test/factbase/terms/test_to_integer.rb
+++ b/test/factbase/terms/test_to_integer.rb
@@ -1,9 +1,10 @@
 # frozen_string_literal: true
 
-require_relative '../../../lib/factbase/term'
-require_relative '../../../lib/factbase/terms/to_integer'
 # SPDX-FileCopyrightText: Copyright (c) 2024-2026 Yegor Bugayenko
 # SPDX-License-Identifier: MIT
+
+require_relative '../../../lib/factbase/term'
+require_relative '../../../lib/factbase/terms/to_integer'
 
 require_relative '../../test__helper'
 
@@ -14,5 +15,13 @@ require_relative '../../test__helper'
 class TestToInteger < Factbase::Test
   def test_to_integer
     assert_equal('Integer', Factbase::ToInteger.new([[42, 'hello']]).evaluate(fact, [], Factbase.new).class.to_s)
+  end
+
+  def test_rejects_invalid_value
+    t = Factbase::ToInteger.new(['abc'])
+    assert_includes(
+      assert_raises(RuntimeError) { t.evaluate(fact, [], Factbase.new) }.message,
+      "Cannot convert 'abc' to Integer in (to_integer ...):"
+    )
   end
 end


### PR DESCRIPTION
Closes #661.

Added rescue blocks in `ToFloat#evaluate` and `ToInteger#evaluate` matching the pattern used by `ToTime#parse`, so invalid input produces a clean `RuntimeError` instead of a raw `ArgumentError` that gets double-escaped by `Term#evaluate`.

Messages:
- `Cannot convert '<value>' to Float in (to_float ...): <reason>`
- `Cannot convert '<value>' to Integer in (to_integer ...): <reason>`