### PR TITLE
#672: fix to_integer crash on Float values

### DIFF
--- a/lib/factbase/terms/to_integer.rb
+++ b/lib/factbase/terms/to_integer.rb
@@ -29,7 +29,7 @@ class Factbase::ToInteger < Factbase::TermBase
   private
 
   def to_integer(value)
-    Integer(value.to_s)
+    Integer(value)
   rescue ArgumentError, TypeError => e
     raise(RuntimeError, "Cannot convert '#{value}' to Integer in (to_integer ...): #{e.message}")
   end

--- a/test/factbase/terms/test_to_integer.rb
+++ b/test/factbase/terms/test_to_integer.rb
@@ -17,6 +17,10 @@ class TestToInteger < Factbase::Test
     assert_equal('Integer', Factbase::ToInteger.new([[42, 'hello']]).evaluate(fact, [], Factbase.new).class.to_s)
   end
 
+  def test_truncates_float
+    assert_equal(5_961_600, Factbase::ToInteger.new([[5_961_600.0]]).evaluate(fact, [], Factbase.new))
+  end
+
   def test_rejects_invalid_value
     t = Factbase::ToInteger.new(['abc'])
     assert_includes(


### PR DESCRIPTION
Closes #672.

## Problem

`ToInteger#to_integer` converted values via `Integer(value.to_s)`. When the operand is a `Float`, `value.to_s` yields a decimal string like `"5961600.0"`, and `Integer("5961600.0")` raises `ArgumentError: invalid value for Integer()`. This was a regression introduced in 0.19.14 by the fix for #661 (which copied `to_time`'s `Time.parse(value.to_s)` shape). It broke the common `(to_integer (minus when X))` idiom, since subtracting two times produces a Float number of seconds.

## Fix

Drop the `.to_s` and call `Integer(value)` directly. `Integer()` already accepts numeric arguments and truncates Floats, so `Integer(5961600.0)` returns `5961600`. The surrounding `rescue ArgumentError, TypeError` from #661 stays and still catches genuinely invalid input like `Integer("abc")`, preserving the descriptive-error behavior.

## Tests

Added `test_truncates_float` covering the Float truncation path. All `to_integer` tests pass and RuboCop is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FhB2Mvved23UGNgGcE1UWX

---
_Generated by [Claude Code](https://claude.ai/code/session_01FhB2Mvved23UGNgGcE1UWX)_