### PR TITLE
#677: exclude each consumers from query timeout

### DIFF
--- a/lib/factbase/impatient.rb
+++ b/lib/factbase/impatient.rb
@@ -57,9 +57,10 @@ class Factbase::Impatient
 
     def each(fb = @fb, params = {}, &)
       return to_enum(__method__, fb, params) unless block_given?
-      facts = impatient('each') do
-        @fb.query(@term, @maps).each(fb, params).to_a
-      end
+      facts =
+        impatient('each') do
+          @fb.query(@term, @maps).each(fb, params).to_a
+        end
       n = 0
       facts.each do |f|
         yield(f)

--- a/lib/factbase/impatient.rb
+++ b/lib/factbase/impatient.rb
@@ -57,12 +57,13 @@ class Factbase::Impatient
 
     def each(fb = @fb, params = {}, &)
       return to_enum(__method__, fb, params) unless block_given?
+      facts = impatient('each') do
+        @fb.query(@term, @maps).each(fb, params).to_a
+      end
       n = 0
-      impatient('each') do
-        @fb.query(@term, @maps).each(fb, params) do |f|
-          yield(f)
-          n += 1
-        end
+      facts.each do |f|
+        yield(f)
+        n += 1
       end
       n
     end

--- a/test/factbase/test_impatient.rb
+++ b/test/factbase/test_impatient.rb
@@ -154,6 +154,12 @@ class TestImpatient < Factbase::Test
     assert_equal(100, count)
   end
 
+  def test_each_does_not_time_out_consumer
+    fb = Factbase::Impatient.new(Factbase.new, timeout: 0.01)
+    fb.insert
+    assert_equal(1, fb.query('(always)').each { sleep(0.02) })
+  end
+
   def test_custom_timeout
     slow = SlowEnoughFactbase.new
     slow.insert.value = 42


### PR DESCRIPTION
## Summary

- materialize `Impatient#each` query results inside the configured timeout
- invoke the caller's consumer block after the timed query has completed
- add regression coverage showing slow consumer work is not charged to the query timeout

## Validation

- `git diff --check`
- The focused Ruby test suite could not be run locally because Ruby is not installed on this runner, and its Docker daemon is not accessible. The upstream Ruby 3.4 CI should exercise the regression test on Linux, macOS, and Windows.

Fixes #677
