### PR TITLE
#670: raise clean ArgumentError on zero divisor in div term

### DIFF
--- a/lib/factbase/terms/arithmetic.rb
+++ b/lib/factbase/terms/arithmetic.rb
@@ -50,6 +50,7 @@ class Factbase::Arithmetic < Factbase::TermBase
           raise(ArgumentError, "Unknown time unit '#{units}' in '#{r}'")
         end
     end
+    raise(ArgumentError, 'Cannot divide by zero') if @op == :/ && r.is_a?(Numeric) && r.zero?
     v.__send__(@op, r)
   end
 end

--- a/test/factbase/terms/test_div.rb
+++ b/test/factbase/terms/test_div.rb
@@ -16,6 +16,26 @@ class TestDiv < Factbase::Test
     assert_equal(420, Factbase::Div.new([:balance, 100]).evaluate(fact('balance' => 42_000), [], Factbase.new))
   end
 
+  def test_div_by_integer_zero
+    t = Factbase::Div.new([:balance, 0])
+    assert_includes(
+      assert_raises(ArgumentError) do
+        t.evaluate(fact('balance' => 42), [], Factbase.new)
+      end.message,
+      'Cannot divide by zero'
+    )
+  end
+
+  def test_div_by_float_zero
+    t = Factbase::Div.new([:balance, 0.0])
+    assert_includes(
+      assert_raises(ArgumentError) do
+        t.evaluate(fact('balance' => 42.0), [], Factbase.new)
+      end.message,
+      'Cannot divide by zero'
+    )
+  end
+
   def test_div_times_not_supported
     t = Factbase::Div.new([:warranty, Time.new(2024, 1, 1)])
     assert_includes(


### PR DESCRIPTION
Closes #670.

`Factbase::Arithmetic#evaluate` let `Integer#/` raise a raw `ZeroDivisionError` out of `(div a b)` whenever the divisor evaluated to integer `0`, leaking internal file paths and line numbers through `Term#evaluate`'s re-wrap; a `Float` zero divisor meanwhile silently produced `Infinity`. Both zero-divisor paths now raise the same clean, domain-level `ArgumentError` (`Cannot divide by zero`), consistent with how the term already reports other bad input (wrong arity, unknown time units).

Two new tests cover the integer-zero and float-zero divisors; both fail on master (raw `ZeroDivisionError` / `Infinity` respectively).

Tests: test_div, test_math, test_query all green (43 tests, 0 failures); rubocop: no offenses.
