### PR TITLE
#686: treat empty env var as unset in Factbase::Env

### DIFF
--- a/lib/factbase/terms/env.rb
+++ b/lib/factbase/terms/env.rb
@@ -24,10 +24,13 @@ class Factbase::Env < Factbase::TermBase
     assert_args(2)
     n = _values(0, fact, maps, fb)
     return if n.nil?
-    ENV.fetch(n[0].upcase) do
+    value = ENV.fetch(n[0].upcase, nil)
+    if value.nil? || value.empty?
       d = _values(1, fact, maps, fb)
       return if d.nil?
       d[0]
+    else
+      value
     end
   end
 end

--- a/test/factbase/terms/test_env.rb
+++ b/test/factbase/terms/test_env.rb
@@ -23,6 +23,11 @@ class TestEnv < Factbase::Test
     assert_equal('мой друг', Factbase::Env.new(['FOO', 'мой друг']).evaluate(fact, [], Factbase.new))
   end
 
+  def test_default_when_value_is_empty
+    ENV.store('FOO', '')
+    assert_equal('мой друг', Factbase::Env.new(['FOO', 'мой друг']).evaluate(fact, [], Factbase.new))
+  end
+
   def test_when_default_is_absent
     ENV.delete('FOO')
     t = Factbase::Env.new(['FOO'])


### PR DESCRIPTION
Closes #686

`Factbase::Env#evaluate` (the `env` DSL term) used `ENV.fetch(n[0].upcase) { default }`, which only falls back to the default when the environment variable is unset. If the variable is set but empty (`''`), `fetch` returned the empty string instead of the default.

This breaks the common `(to_time (env 'TODAY' '#{Time.now.utc.iso8601}'))` pattern used by several downstream judges in zerocracy/judges-action. If `TODAY` is set but empty, `Factbase::ToTime#parse` calls `Time.parse('')`, which raises.

Fix: read the value with `ENV.fetch(n[0].upcase, nil)` and treat `nil` or an empty string the same way, falling back to the default in both cases.

Added a test for the empty-string case (`test_default_when_value_is_empty`).

Verified:
- All 6 tests in `test/factbase/terms/test_env.rb` pass (5 existing + 1 new).
- rubocop clean.
