### PR TITLE
#688: guard against nil format string in Sprintf#evaluate

### DIFF
--- a/lib/factbase/terms/sprintf.rb
+++ b/lib/factbase/terms/sprintf.rb
@@ -22,10 +22,9 @@ class Factbase::Sprintf < Factbase::TermBase
   # @param [Factbase] fb Factbase to use for sub-queries
   # @return [String] The formatted string
   def evaluate(fact, maps, fb)
-    formatted(
-      _values(0, fact, maps, fb)[0],
-      (1..(@operands.length - 1)).map { |i| _values(i, fact, maps, fb)&.first }
-    )
+    fmt = _values(0, fact, maps, fb)
+    return if fmt.nil?
+    formatted(fmt[0], (1..(@operands.length - 1)).map { |i| _values(i, fact, maps, fb)&.first })
   end
 
   private

--- a/test/factbase/terms/test_sprintf.rb
+++ b/test/factbase/terms/test_sprintf.rb
@@ -22,6 +22,11 @@ class TestSprintf < Factbase::Test
     assert_includes(e.message, 'invalid value for Integer')
   end
 
+  def test_missing_format_property_returns_nil
+    fb = Factbase.new
+    assert_nil(Factbase::Sprintf.new([:missing_prop, 'x']).evaluate(fb.insert, [], fb))
+  end
+
   def test_rejects_missing_format_operand
     t = Factbase::Sprintf.new(['%s %s', 'hello'])
     e =


### PR DESCRIPTION
Closes #688.

`Factbase::Sprintf#evaluate` read its first operand (the format string) with a bare `[0]`, while every sibling operand already used the safe `&.first`. `_values` returns bare `nil` when the referenced property is absent from the fact, so `(sprintf $missing_prop 'hi')` raised `NoMethodError: undefined method '[]' for nil`, which the term dispatcher then reported as the misleading "Probably the term 'sprintf' is not defined".

This guards the format-string operand and returns `nil` for a missing property, matching how `Env#evaluate` was fixed in #666 for the same bug class (#655). Added a regression test.
