### PR TITLE
#695: sort the printed facts by kind, then by value

### DIFF
--- a/lib/factbase/flatten.rb
+++ b/lib/factbase/flatten.rb
@@ -21,8 +21,26 @@ class Factbase::Flatten
   # @return [Array<HashMap>] The hashmaps, but improved
   def it
     @maps
-      .sort_by { |m| Array(m[@sorter]).map(&:to_s) }
+      .sort_by { |m| Array(m[@sorter]).map { |v| Factbase::Flatten.key(v) } }
       .map { |m| m.sort.to_h }
       .map! { |m| m.transform_values { |v| v.size == 1 ? v[0] : v } }
+  end
+
+  # The sorting key of one value: the name of its kind, then the value
+  # itself for the kinds that compare, and its text for the rest. Values
+  # of different kinds never meet in a comparison this way, which is what
+  # made the plain value raise (#618), while numbers stay in their own
+  # order instead of the order of their digits (#695).
+  # @param [Object] value The value of the sorter property
+  # @return [Array] The key to sort by
+  def self.key(value)
+    case value
+    when Numeric
+      [0, value, '']
+    when Time
+      [1, Float(value), '']
+    else
+      [2, 0, value.to_s]
+    end
   end
 end

--- a/test/factbase/test_flatten.rb
+++ b/test/factbase/test_flatten.rb
@@ -61,11 +61,6 @@ class TestFlatten < Factbase::Test
   end
 
   def test_sorts_values_of_mixed_kinds
-    assert_equal(
-      3,
-      Factbase::Flatten.new(
-        [{ 'x' => ['b'] }, { 'x' => [1] }, { 'x' => [Time.now] }], 'x'
-      ).it.size
-    )
+    assert_equal(3, Factbase::Flatten.new([{ 'x' => ['b'] }, { 'x' => [1] }, { 'x' => [Time.now] }], 'x').it.size)
   end
 end

--- a/test/factbase/test_flatten.rb
+++ b/test/factbase/test_flatten.rb
@@ -33,4 +33,39 @@ class TestFlatten < Factbase::Test
       Factbase::Flatten.new([{ 'foo' => [42], 'i' => 1 }, { 'foo' => ['hello'], 'i' => 0 }], 'foo').it.size
     )
   end
+
+  def test_sorts_numbers_in_their_own_order
+    assert_equal(
+      [1, 2, 10],
+      Factbase::Flatten.new(
+        [{ 'i' => [10] }, { 'i' => [2] }, { 'i' => [1] }], 'i'
+      ).it.map { |m| m['i'] }
+    )
+  end
+
+  def test_sorts_strings_alphabetically
+    assert_equal(
+      %w[a b c],
+      Factbase::Flatten.new(
+        [{ 'i' => ['c'] }, { 'i' => ['a'] }, { 'i' => ['b'] }], 'i'
+      ).it.map { |m| m['i'] }
+    )
+  end
+
+  def test_sorts_times_chronologically
+    now = Time.now
+    assert_equal(
+      [now, now + 60],
+      Factbase::Flatten.new([{ 't' => [now + 60] }, { 't' => [now] }], 't').it.map { |m| m['t'] }
+    )
+  end
+
+  def test_sorts_values_of_mixed_kinds
+    assert_equal(
+      3,
+      Factbase::Flatten.new(
+        [{ 'x' => ['b'] }, { 'x' => [1] }, { 'x' => [Time.now] }], 'x'
+      ).it.size
+    )
+  end
 end


### PR DESCRIPTION
`Flatten#it` turned every sorter value into a string before sorting, so integer
`_id`s were ordered by their digits and a factbase of twelve facts printed as
1, 10, 11, 12, 2, 3, ... through `ToJSON`, `ToYAML` and `ToXML` alike.

The `to_s` was there to stop `sort_by` raising when two facts hold values of
different types (#618). The key now carries the kind first and the value
second, so values of different kinds never reach a comparison with each other,
and numbers keep their own order.

`Flatten.new((1..12).map { |n| {'_id'=>[n]} }, '_id')` gives 1..12 with this
and 1, 10, 11, 12, 2, ... without it. The existing incompatible-types test
still passes, and four new ones cover numbers, strings, times and a mix.

Closes #695
