### PR TITLE
#701: refuse a negative position

### DIFF
--- a/lib/factbase/terms/nth.rb
+++ b/lib/factbase/terms/nth.rb
@@ -24,6 +24,7 @@ class Factbase::Nth < Factbase::TermBase
     assert_args(2)
     pos = @operands[0]
     raise(ArgumentError, "An integer is expected, but #{pos} provided") unless pos.is_a?(Integer)
+    raise(ArgumentError, "A non-negative position is expected, but #{pos} provided") if pos.negative?
     k = @operands[1]
     raise(ArgumentError, "A symbol is expected, but #{k} provided") unless k.is_a?(Symbol)
     m = maps[pos]

--- a/test/factbase/terms/test_nth.rb
+++ b/test/factbase/terms/test_nth.rb
@@ -22,6 +22,15 @@ class TestNth < Factbase::Test
     )
   end
 
+  def test_refuses_a_negative_position
+    t = Factbase::Nth.new([-1, :letter])
+    e =
+      assert_raises(ArgumentError) do
+        t.evaluate(fact, [{ 'letter' => 'a' }, { 'letter' => 'b' }], Factbase.new)
+      end
+    assert_includes(e.message, 'A non-negative position is expected, but -1 provided', e.message)
+  end
+
   def test_nth_out_of_bounds
     assert_nil(
       Factbase::Nth.new([5, :letter]).evaluate(


### PR DESCRIPTION
`Nth#evaluate` checked that the position is an Integer but not that it is a position. Ruby reads a negative index from the end, so `(nth -1 f)` answered the last fact instead of being refused, while a position past the end answered nil. Two ends of the same mistake behaved differently.

Closes #701
