### PR TITLE
#702: refuse a negative count

### DIFF
--- a/lib/factbase/terms/head.rb
+++ b/lib/factbase/terms/head.rb
@@ -28,6 +28,7 @@ class Factbase::Head < Factbase::TermBase
     assert_args(2)
     max = @operands[0]
     raise(ArgumentError, "An integer is expected as first argument of '#{@op}'") unless max.is_a?(Integer)
+    raise(ArgumentError, "A non-negative count is expected by '#{@op}', but #{max} provided") if max.negative?
     term = @operands[1]
     raise(ArgumentError, "A term is expected, but '#{term}' provided") unless term.is_a?(Factbase::Term)
     fb.query(term, maps).each(fb, params).to_a

--- a/test/factbase/terms/test_head.rb
+++ b/test/factbase/terms/test_head.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+require_relative '../../test__helper'
+require_relative '../../../lib/factbase/term'
+require_relative '../../../lib/factbase/terms/head'
+
+# Test for head term.
+# Author:: Yegor Bugayenko (yegor256@gmail.com)
+# Copyright:: Copyright (c) 2024-2026 Yegor Bugayenko
+# License:: MIT
+class TestHead < Factbase::Test
+  def test_takes_the_first_ones
+    maps = [{ 'foo' => [1] }, { 'foo' => [2] }, { 'foo' => [3] }]
+    t = Factbase::Term.new(:head, [2, Factbase::Term.new(:always, [])])
+    assert_equal(2, t.predict(maps, Factbase.new(maps), {}).size)
+  end
+
+  def test_refuses_a_negative_count
+    maps = [{ 'foo' => [1] }]
+    t = Factbase::Term.new(:head, [-1, Factbase::Term.new(:always, [])])
+    e = assert_raises(ArgumentError) { t.predict(maps, Factbase.new(maps), {}) }
+    assert_includes(e.message, "A non-negative count is expected by 'head', but -1 provided", e.message)
+  end
+end

--- a/test/factbase/terms/test_head.rb
+++ b/test/factbase/terms/test_head.rb
@@ -3,9 +3,9 @@
 # SPDX-FileCopyrightText: Copyright (c) 2024-2026 Yegor Bugayenko
 # SPDX-License-Identifier: MIT
 
-require_relative '../../test__helper'
 require_relative '../../../lib/factbase/term'
 require_relative '../../../lib/factbase/terms/head'
+require_relative '../../test__helper'
 
 # Test for head term.
 # Author:: Yegor Bugayenko (yegor256@gmail.com)
@@ -14,8 +14,10 @@ require_relative '../../../lib/factbase/terms/head'
 class TestHead < Factbase::Test
   def test_takes_the_first_ones
     maps = [{ 'foo' => [1] }, { 'foo' => [2] }, { 'foo' => [3] }]
-    t = Factbase::Term.new(:head, [2, Factbase::Term.new(:always, [])])
-    assert_equal(2, t.predict(maps, Factbase.new(maps), {}).size)
+    assert_equal(
+      2,
+      Factbase::Term.new(:head, [2, Factbase::Term.new(:always, [])]).predict(maps, Factbase.new(maps), {}).size
+    )
   end
 
   def test_refuses_a_negative_count


### PR DESCRIPTION
A negative count passed the Integer check and reached `Array#take`, which raised `attempt to take negative size` with nothing about the term in it. Every other malformed operand of `head` is reported with the term named.

The repository had no test file for this term, so the new one also covers the normal case.

Closes #702
