### PR TITLE
#688: name the format operand the fact does not have

### DIFF
--- a/lib/factbase/terms/sprintf.rb
+++ b/lib/factbase/terms/sprintf.rb
@@ -22,8 +22,12 @@ class Factbase::Sprintf < Factbase::TermBase
   # @param [Factbase] fb Factbase to use for sub-queries
   # @return [String] The formatted string
   def evaluate(fact, maps, fb)
+    fmt = _values(0, fact, maps, fb)&.first
+    if fmt.nil?
+      raise(ArgumentError, "The format of 'sprintf' is #{@operands[0].inspect}, which the fact doesn't have")
+    end
     formatted(
-      _values(0, fact, maps, fb)[0],
+      fmt,
       (1..(@operands.length - 1)).map { |i| _values(i, fact, maps, fb)&.first }
     )
   end

--- a/lib/factbase/terms/sprintf.rb
+++ b/lib/factbase/terms/sprintf.rb
@@ -26,10 +26,7 @@ class Factbase::Sprintf < Factbase::TermBase
     if fmt.nil?
       raise(ArgumentError, "The format of 'sprintf' is #{@operands[0].inspect}, which the fact doesn't have")
     end
-    formatted(
-      fmt,
-      (1..(@operands.length - 1)).map { |i| _values(i, fact, maps, fb)&.first }
-    )
+    formatted(fmt, (1..(@operands.length - 1)).map { |i| _values(i, fact, maps, fb)&.first })
   end
 
   private

--- a/test/factbase/terms/test_sprintf.rb
+++ b/test/factbase/terms/test_sprintf.rb
@@ -12,6 +12,15 @@ class TestSprintf < Factbase::Test
     assert_equal('hi, Jeff!', Factbase::Sprintf.new(['hi, %s!', 'Jeff']).evaluate(fact, [], Factbase.new))
   end
 
+  def test_rejects_a_format_the_fact_does_not_have
+    t = Factbase::Sprintf.new([:missing, 'Jeff'])
+    e =
+      assert_raises(ArgumentError) do
+        t.evaluate(fact, [], Factbase.new)
+      end
+    assert_includes(e.message, "The format of 'sprintf' is :missing, which the fact doesn't have", e.message)
+  end
+
   def test_rejects_invalid_format_operand
     t = Factbase::Sprintf.new(['%d', 'hello'])
     e =


### PR DESCRIPTION
Every operand but the first used `&.first`; the format string was indexed with `[0]` straight on the result of `_values`, which is nil when the referenced property is absent. `nil[0]` then raised `NoMethodError`, and the term dispatcher rewrote it as "Probably the term 'sprintf' is not defined", which hid the real cause.

The format operand is now read the same way as the others and, when it is not there, the error names it.

Closes #688
