### PR TITLE
#713: let the empty string literal through the tokenizer

### DIFF
--- a/lib/factbase/syntax.rb
+++ b/lib/factbase/syntax.rb
@@ -137,7 +137,7 @@ class Factbase::Syntax
       if t.is_a?(Symbol)
         t
       elsif t.start_with?('\'', '"')
-        raise(ArgumentError, 'String literal can\'t be empty') if t.length <= 2
+        raise(ArgumentError, 'String literal is not closed') if t.length < 2
         t[1..-2]
       elsif t.match?(/^(\+|-)?[0-9]+$/)
         Integer(t, 10)

--- a/test/factbase/test_syntax.rb
+++ b/test/factbase/test_syntax.rb
@@ -22,6 +22,16 @@ class TestSyntax < Factbase::Test
     end
   end
 
+  def test_parses_empty_string_literal
+    assert_equal("(eq foo '')", Factbase::Syntax.new('(eq foo "")').to_term.to_s)
+  end
+
+  def test_matches_empty_string_literal
+    fb = Factbase.new
+    fb.insert.foo = 'hello'
+    assert_equal(0, fb.query('(eq foo "")').each.to_a.size)
+  end
+
   def test_makes_abstract_terms
     {
       '(foo $bar)' => true,
@@ -115,7 +125,6 @@ class TestSyntax < Factbase::Test
       '(bad-term-name 42)',
       '(foo x y (z t (f 42 ',
       ')foo ) y z)',
-      '(x "")',
       ")y 42 'Hey you)",
       ')',
       '"'


### PR DESCRIPTION
`""` was refused outright, because the length check counted the quotes, so
`(eq foo "")`, `(ends_with foo "")` and any format position needing an empty
string failed to parse. The check now only catches a token that is not a closed
literal at all.

A fact still cannot hold an empty value, `fact.rb` refuses that; this is about
naming the empty string in a query.

Closes #713
