### PR TITLE
#712: refuse extra operands in sum and count

### DIFF
--- a/lib/factbase/terms/count.rb
+++ b/lib/factbase/terms/count.rb
@@ -20,6 +20,7 @@ class Factbase::Count < Factbase::TermBase
   # @param [Factbase] _fb Factbase to use for sub-queries
   # @return [Integer] The count of maps
   def evaluate(_fact, maps, _fb)
+    assert_args(0)
     maps.size
   end
 end

--- a/lib/factbase/terms/sum.rb
+++ b/lib/factbase/terms/sum.rb
@@ -22,6 +22,7 @@ class Factbase::Sum < Factbase::TermBase
   # @param [Factbase] _fb Factbase to use for sub-queries
   # @return [Integer] The sum of values for the specified key across all maps
   def evaluate(_fact, maps, _fb)
+    assert_args(1)
     k = @operands[0]
     raise(ArgumentError, "A symbol is expected, but '#{k}' provided") unless k.is_a?(Symbol)
     sum = 0

--- a/test/factbase/terms/test_count.rb
+++ b/test/factbase/terms/test_count.rb
@@ -19,4 +19,13 @@ class TestCount < Factbase::Test
   def test_count_emptyseveral
     assert_equal(0, Factbase::Count.new([]).evaluate(fact, {}, Factbase.new))
   end
+
+  def test_refuses_operands
+    assert_includes(
+      assert_raises(ArgumentError) do
+        Factbase::Count.new(%i[a b c]).evaluate(fact, { 'a' => 1 }, Factbase.new)
+      end.message,
+      "Too many (3) operands for 'count' (0 expected)"
+    )
+  end
 end

--- a/test/factbase/terms/test_sum.rb
+++ b/test/factbase/terms/test_sum.rb
@@ -28,4 +28,13 @@ class TestSum < Factbase::Test
       Factbase::Sum.new([:absent]).evaluate(fact, [{ 'value' => 40 }, {}, { 'value' => 50 }], Factbase.new)
     )
   end
+
+  def test_refuses_extra_operands
+    assert_includes(
+      assert_raises(ArgumentError) do
+        Factbase::Sum.new(%i[a b]).evaluate(fact, [{ 'a' => 1, 'b' => 10 }], Factbase.new)
+      end.message,
+      "Too many (2) operands for 'sum' (1 expected)"
+    )
+  end
 end


### PR DESCRIPTION
`(sum a b)` quietly returned the sum of `a` alone and `(count a b c)` ignored its
operands. Almost every other term guards with `assert_args`, these two now do the
same.

Closes #712
