### PR TITLE
#710: concatenate all values of an operand

### DIFF
--- a/lib/factbase/terms/concat.rb
+++ b/lib/factbase/terms/concat.rb
@@ -21,6 +21,6 @@ class Factbase::Concat < Factbase::TermBase
   # @param [Factbase] fb Factbase to use for sub-queries
   # @return [String] The concatenated string
   def evaluate(fact, maps, fb)
-    (0..(@operands.length - 1)).map { |i| _values(i, fact, maps, fb)&.first }.join
+    (0..(@operands.length - 1)).map { |i| _values(i, fact, maps, fb)&.join }.join
   end
 end

--- a/test/factbase/terms/test_concat.rb
+++ b/test/factbase/terms/test_concat.rb
@@ -20,4 +20,12 @@ class TestConcat < Factbase::Test
   def test_concat_empty
     assert_equal('', Factbase::Concat.new([]).evaluate(fact, [], Factbase.new))
   end
+
+  def test_concat_all_values_of_a_property
+    fb = Factbase.new
+    f = fb.insert
+    f.foo = 'a'
+    f.foo = 'b'
+    assert_equal('ab', fb.query('(as z (concat foo))').each.to_a.first['z'].first)
+  end
 end


### PR DESCRIPTION
`concat` kept only the first value of each operand, so a multi-valued property
could not be concatenated at all, while the README says it concatenates all `v`.
All values of each operand are joined now.

Closes #710
