### PR TITLE
#709: keep a fact whose property carries a new value

### DIFF
--- a/lib/factbase/terms/unique.rb
+++ b/lib/factbase/terms/unique.rb
@@ -25,6 +25,6 @@ class Factbase::Unique < Factbase::TermBase
     vv = (0..(@operands.size - 1)).map { |i| _values(i, fact, maps, fb) }
     return false if vv.any?(nil)
     tuples = Enumerator.product(*vv).to_a
-    !@seen.intersect?(tuples).tap { tuples.each { |t| @seen << t } }
+    tuples.filter_map { |t| @seen.add?(t) }.any?
   end
 end

--- a/test/factbase/terms/test_unique.rb
+++ b/test/factbase/terms/test_unique.rb
@@ -20,6 +20,14 @@ class TestUnique < Factbase::Test
     assert(t.evaluate(fact('foo' => 1), [], Factbase.new))
   end
 
+  def test_unique_when_one_value_is_new
+    t = Factbase::Unique.new([:foo])
+    assert(t.evaluate(fact('foo' => [1]), [], Factbase.new))
+    assert(t.evaluate(fact('foo' => [1, 2]), [], Factbase.new))
+    assert(t.evaluate(fact('foo' => [3]), [], Factbase.new))
+    refute(t.evaluate(fact('foo' => [1, 2]), [], Factbase.new))
+  end
+
   def test_unique_with_multiple_arguments
     t = Factbase::Term.new(:unique, %i[foo bar])
     assert(t.evaluate(fact('foo' => 1, 'bar' => 'a'), [], Factbase.new))

--- a/test/factbase/test_query.rb
+++ b/test/factbase/test_query.rb
@@ -100,7 +100,7 @@ class TestQuery < Factbase::Test
       '(eq "Integer" (type hi))' => 1,
       '(when (eq num 0) (exists time))' => 2,
       '(when (unique num) (or (eq num 0) (eq num 42)))' => 3,
-      '(unique num)' => 1,
+      '(unique num)' => 2,
       '(unique name)' => 2,
       '(unique pi)' => 1,
       '(many num)' => 1,


### PR DESCRIPTION
The README says `(unique p1 p2 ...)` is true when at least one value has not been
seen yet, and false when the whole combination is a duplicate. The code returned
false as soon as any tuple was known, so a fact carrying a brand new value was
dropped because of an old one next to it.

Single-valued properties behave exactly as before.

Closes #709
