### PR TITLE
#708: round Time the same way for every comparison

### DIFF
--- a/lib/factbase/terms/compare.rb
+++ b/lib/factbase/terms/compare.rb
@@ -28,9 +28,9 @@ class Factbase::Compare < Factbase::TermBase
     rights = _values(1, fact, maps, fb)
     return false if rights.nil?
     lefts.any? do |l|
-      l = l.floor if l.is_a?(Time) && @op == :==
+      l = l.floor if l.is_a?(Time)
       rights.any? do |r|
-        r = r.floor if r.is_a?(Time) && @op == :==
+        r = r.floor if r.is_a?(Time)
         _compare(l, r)
       end
     end

--- a/test/factbase/terms/test_compare.rb
+++ b/test/factbase/terms/test_compare.rb
@@ -17,6 +17,16 @@ class TestCompare < Factbase::Test
     refute(Factbase::Compare.new(:<, [4, 2]).evaluate(fact, [], Factbase.new), 'Expected 2 < 4 to be true')
   end
 
+  def test_rounds_time_the_same_way_for_every_operator
+    t = Time.utc(2024, 1, 1, 0, 0, 0, 500_000)
+    whole = Time.utc(2024, 1, 1)
+    assert(Factbase::Compare.new(:==, [t, whole]).evaluate(fact, [], Factbase.new))
+    assert(Factbase::Compare.new(:<=, [t, whole]).evaluate(fact, [], Factbase.new))
+    assert(Factbase::Compare.new(:>=, [t, whole]).evaluate(fact, [], Factbase.new))
+    refute(Factbase::Compare.new(:<, [t, whole]).evaluate(fact, [], Factbase.new))
+    refute(Factbase::Compare.new(:>, [t, whole]).evaluate(fact, [], Factbase.new))
+  end
+
   def test_wraps_incompatible_type_comparison
     t = Factbase::Compare.new(:>, [42, 'hello'])
     e = assert_raises(RuntimeError) { t.evaluate(fact, [], Factbase.new) }


### PR DESCRIPTION
The truncation of `Time` to whole seconds was gated on `eq`, so the same pair
could be equal and strictly greater at once, and `(or (lt a b) (eq a b))`
disagreed with `(lte a b)`. All five operators floor `Time` now, so the ordering
is total again.

Closes #708
