### PR TITLE
#707: keep the facts that have no value for the sorting property

### DIFF
--- a/lib/factbase/terms/sorted.rb
+++ b/lib/factbase/terms/sorted.rb
@@ -30,9 +30,8 @@ class Factbase::Sorted < Factbase::TermBase
     raise(ArgumentError, "A symbol is expected as first argument of 'sorted'") unless prop.is_a?(Symbol)
     term = @operands[1]
     raise(ArgumentError, "A term is expected, but '#{term}' provided") unless term.is_a?(Factbase::Term)
-    fb.query(term, maps).each(fb, params).to_a
-      .reject { |m| m[prop].nil? }
-      .sort_by { |m| m[prop].first }
+    blank, valued = fb.query(term, maps).each(fb, params).to_a.partition { |m| m[prop].nil? }
+    (valued.sort_by { |m| m[prop].first } + blank)
       .map { |m| m.all_properties.to_h { |k| [k, m[k]] } }
   end
 end

--- a/test/factbase/terms/test_sorted.rb
+++ b/test/factbase/terms/test_sorted.rb
@@ -24,6 +24,16 @@ class TestSorted < Factbase::Test
     assert_equal('first second third', list.map { |m| m['y'].first }.join(' '))
   end
 
+  def test_keeps_facts_without_the_property
+    list = Factbase::Syntax.new('(sorted x (always))').to_term.predict(
+      [
+        { 'x' => [8], 'y' => ['third'] }, { 'y' => ['nothing'] },
+        { 'x' => [1], 'y' => ['first'] }
+      ], Factbase.new, {}
+    )
+    assert_equal('first third nothing', list.map { |m| m['y'].first }.join(' '))
+  end
+
   def test_join_and_sort
     ff = Factbase.new(
       [


### PR DESCRIPTION
`evaluate` returns true for every fact, so `sorted` is meant to reorder and keep
everything, but `predict` dropped the facts without a value for the property.
The candidate set was a strict subset of what the term accepts, and a `count`
inside an `agg` came out wrong. `inverted` and `head` keep everything.

Facts without the property now go to the end of the sorted list.

Closes #707
