### PR TITLE
#711: leave a non-term operand alone while simplifying

### DIFF
--- a/lib/factbase/terms/simplified.rb
+++ b/lib/factbase/terms/simplified.rb
@@ -20,7 +20,7 @@ class Factbase::Simplified
     strs = []
     ops = []
     @operands.each do |o|
-      o = o.simplify
+      o = o.simplify if o.is_a?(Factbase::Term)
       s = o.to_s
       next if strs.include?(s)
       strs << s

--- a/test/factbase/terms/test_and.rb
+++ b/test/factbase/terms/test_and.rb
@@ -5,6 +5,7 @@ require_relative '../../../lib/factbase/terms/and'
 # SPDX-FileCopyrightText: Copyright (c) 2024-2026 Yegor Bugayenko
 # SPDX-License-Identifier: MIT
 
+require_relative '../../../lib/factbase/syntax'
 require_relative '../../test__helper'
 
 # Test for the 'and' term.
@@ -18,5 +19,9 @@ class TestAnd < Factbase::Test
 
   def test_and_false
     refute(Factbase::And.new([Factbase::Always.new([]), Factbase::Never.new([])]).evaluate(fact, [], Factbase.new))
+  end
+
+  def test_parses_a_non_term_operand
+    assert_equal(%((and (eq a 1) 5)), Factbase::Syntax.new(%((and (eq a 1) 5))).to_term.to_s)
   end
 end

--- a/test/factbase/terms/test_or.rb
+++ b/test/factbase/terms/test_or.rb
@@ -5,6 +5,7 @@ require_relative '../../../lib/factbase/terms/or'
 # SPDX-FileCopyrightText: Copyright (c) 2024-2026 Yegor Bugayenko
 # SPDX-License-Identifier: MIT
 
+require_relative '../../../lib/factbase/syntax'
 require_relative '../../test__helper'
 
 # Test for the 'or' term.
@@ -18,5 +19,18 @@ class TestOr < Factbase::Test
 
   def test_or_false
     refute(Factbase::Or.new([Factbase::Never.new([]), Factbase::Never.new([])]).evaluate(fact, [], Factbase.new))
+  end
+
+  def test_parses_a_non_term_operand
+    assert_equal(%((or foo (eq a 1))), Factbase::Syntax.new(%((or foo (eq a 1)))).to_term.to_s)
+  end
+
+  def test_names_the_bad_operand_when_evaluating
+    fb = Factbase.new
+    fb.insert.foo = 'x'
+    assert_includes(
+      assert_raises(StandardError) { fb.query('(or foo (eq a 1))').each.to_a }.message,
+      'Boolean is expected, while String received from foo'
+    )
   end
 end


### PR DESCRIPTION
`Simplified#unique` called `simplify` on every operand, and only `Factbase::Term`
has that method, so `(or foo (eq a 1))` and `(and (eq a 1) 5)` died at parse time
with an internal `NoMethodError` wrapped as `Broken`.

Non-term operands are left alone now. Both queries parse, and evaluation reports
the bad operand by name the way it does for `not`.

Closes #711
