### PR TITLE
#721: count facts in the size attribute

### DIFF
--- a/lib/factbase/to_xml.rb
+++ b/lib/factbase/to_xml.rb
@@ -29,7 +29,7 @@ class Factbase::ToXML
   # Convert the entire factbase into XML.
   # @return [String] The factbase in XML format
   def xml
-    meta = { version: Factbase::VERSION, size: @fb.export.size }
+    meta = { version: Factbase::VERSION, size: @fb.size }
     Nokogiri::XML::Builder.new(encoding: 'UTF-8') do |xml|
       xml.fb(meta) do
         Factbase::Flatten.new(@fb.each.to_a, @sorter).it.each do |m|

--- a/test/factbase/test_to_xml.rb
+++ b/test/factbase/test_to_xml.rb
@@ -33,6 +33,13 @@ class TestToXML < Factbase::Test
     xml = Nokogiri::XML.parse(Factbase::ToXML.new(fb).xml)
     refute_empty(xml.xpath('/fb[@version]'))
     refute_empty(xml.xpath('/fb[@size]'))
+    assert_equal('1', xml.xpath('/fb/@size').text)
+  end
+
+  def test_size_counts_the_facts
+    fb = Factbase.new
+    3.times { |i| fb.insert.x = i }
+    assert_equal('3', Nokogiri::XML.parse(Factbase::ToXML.new(fb).xml).xpath('/fb/@size').text)
   end
 
   def test_to_xml_with_short_names


### PR DESCRIPTION
The `size` attribute held the byte length of `Marshal.dump` of the whole
factbase, while `size` means a fact count everywhere else in the API. The dump
was made purely for that one number, and it made `ToXML` unusable on a factbase
that has no `export`, such as the one handed to a transaction block.

Closes #721
