### PR TITLE
#720: print a Time in ISO 8601 in JSON too

### DIFF
--- a/lib/factbase/to_json.rb
+++ b/lib/factbase/to_json.rb
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: MIT
 
 require 'json'
+require 'time'
 require_relative '../factbase'
 require_relative '../factbase/flatten'
 
@@ -28,6 +29,17 @@ class Factbase::ToJSON
   # Convert the entire factbase into JSON.
   # @return [String] The factbase in JSON format
   def json
-    Factbase::Flatten.new(@fb.each.to_a, @sorter).it.to_json
+    Factbase::Flatten.new(@fb.each.to_a, @sorter).it.map do |m|
+      m.transform_values { |vv| vv.is_a?(Array) ? vv.map { |v| plain(v) } : plain(vv) }
+    end.to_json
+  end
+
+  private
+
+  # Render one value the way ToXML renders it.
+  # @param [Object] val The value
+  # @return [Object] The value, with a Time turned into ISO 8601
+  def plain(val)
+    val.is_a?(Time) ? val.utc.iso8601(6) : val
   end
 end

--- a/lib/factbase/to_xml.rb
+++ b/lib/factbase/to_xml.rb
@@ -55,7 +55,7 @@ class Factbase::ToXML
 
   def to_str(val)
     if val.is_a?(Time)
-      val.utc.iso8601
+      val.utc.iso8601(6)
     else
       val.to_s
     end

--- a/test/factbase/test_to_json.rb
+++ b/test/factbase/test_to_json.rb
@@ -43,6 +43,12 @@ class TestToJSON < Factbase::Test
     refute_empty(json[0]['when'])
   end
 
+  def test_time_value_in_iso8601
+    fb = Factbase.new
+    fb.insert.when = Time.utc(2026, 9, 1, 10, 20, 30, 123_456)
+    assert_equal('2026-09-01T10:20:30.123456Z', JSON.parse(Factbase::ToJSON.new(fb).json)[0]['when'])
+  end
+
   def test_string_value
     fb = Factbase.new
     fb.insert.text = 'hello'

--- a/test/factbase/test_to_xml.rb
+++ b/test/factbase/test_to_xml.rb
@@ -18,7 +18,10 @@ class TestToXML < Factbase::Test
     fb.insert.t = Time.now
     xml = Nokogiri::XML.parse(Factbase::ToXML.new(fb).xml)
     refute_empty(xml.xpath('/fb/f[t]'))
-    assert_match(/^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$/, xml.xpath('/fb/f/t/text()').text)
+    assert_match(
+      /^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}\.[0-9]{6}Z$/,
+      xml.xpath('/fb/f/t/text()').text
+    )
   end
 
   def test_complex_rendering


### PR DESCRIPTION
`ToJSON` had no `Time` handling, so a stored time came out as Ruby's
`Time#to_s`, which is not ISO 8601 and drops the sub-second part the factbase
keeps. It now prints the same ISO 8601 string `ToXML` prints, and both keep
microseconds, so the two agree with what is actually stored.

Closes #720
