### PR TITLE
#716: restore the check when a transaction is aborted

### DIFF
--- a/lib/factbase/rules.rb
+++ b/lib/factbase/rules.rb
@@ -51,8 +51,11 @@ class Factbase::Rules
     @check = later
     @fb.txn do |fbt|
       churn = Factbase::Churn.new
-      yield(Factbase::Tallied.new(Factbase::Rules.new(fbt, @rules, @check, uid: @uid), churn))
-      @check = before
+      begin
+        yield(Factbase::Tallied.new(Factbase::Rules.new(fbt, @rules, @check, uid: @uid), churn))
+      ensure
+        @check = before
+      end
       unless churn.zero?
         fbt.query('(always)').each do |f|
           next unless later.include?(f)

--- a/test/factbase/test_rules.rb
+++ b/test/factbase/test_rules.rb
@@ -32,6 +32,30 @@ class TestRules < Factbase::Test
     end
   end
 
+  def test_keeps_checking_after_a_rollback
+    fb = Factbase::Rules.new(Factbase.new, '(exists foo)')
+    fb.txn do |fbt|
+      fbt.insert.foo = 42
+      raise(Factbase::Rollback)
+    end
+    assert_raises(StandardError) do
+      fb.insert.bar = 1
+    end
+  end
+
+  def test_keeps_checking_after_a_failed_transaction
+    fb = Factbase::Rules.new(Factbase.new, '(exists foo)')
+    assert_raises(StandardError) do
+      fb.txn do |fbt|
+        fbt.insert.foo = 42
+        raise(StandardError, 'boom')
+      end
+    end
+    assert_raises(StandardError) do
+      fb.insert.bar = 1
+    end
+  end
+
   def test_to_string
     f = Factbase::Rules.new(Factbase.new, '(when (exists a) (exists b))').insert
     f.foo = 42


### PR DESCRIPTION
`@check` was restored after `yield`, inside the transaction block, so a
`Factbase::Rollback` or any other exception skipped the line and left the
instance with a `Later` check that never enforces anything. Every later write
through the same `Rules` object went unchecked.

Restored in an `ensure` now.

Closes #716
