### PR TITLE
#714: find the original copy by identity

### DIFF
--- a/lib/factbase/lazy_taped.rb
+++ b/lib/factbase/lazy_taped.rb
@@ -14,6 +14,7 @@ class Factbase::LazyTaped
     @staged = []
     @copied = false
     @copies = {}.compare_by_identity
+    @sources = {}.compare_by_identity
     @inserted = []
     @deleted = []
     @added = []
@@ -23,7 +24,7 @@ class Factbase::LazyTaped
   # Returns nil if the base hasn't been copied yet or if the fact is new.
   def source_of(copy)
     return unless @copied
-    @copies.key(copy)
+    @sources[copy]
   end
 
   def copied?
@@ -141,6 +142,7 @@ class Factbase::LazyTaped
 
   def _track(copy, original)
     @copies[original] = copy
+    @sources[copy] = original
   end
 
   def _tape(map)

--- a/test/factbase/test_lazy_taped.rb
+++ b/test/factbase/test_lazy_taped.rb
@@ -233,6 +233,30 @@ class TestLazyTaped < Factbase::Test
     assert_equal(2, fb.query('(always)').each.to_a.first.foo)
   end
 
+  def test_modifies_two_equal_facts_in_txn
+    fb = Factbase.new
+    fb.insert.foo = 1
+    fb.insert.foo = 1
+    fb.txn do |fbt|
+      fbt.query('(exists foo)').each { |f| f.bar = 2 }
+    end
+    assert_equal(2, fb.size)
+    assert_equal(2, fb.query('(exists bar)').each.to_a.size)
+  end
+
+  def test_deletes_two_equal_facts_in_txn
+    fb = Factbase.new
+    fb.insert.foo = 1
+    fb.insert.foo = 1
+    assert_equal(
+      2,
+      fb.txn do |fbt|
+        fbt.query('(exists foo)').delete!
+      end.to_i
+    )
+    assert_equal(0, fb.size)
+  end
+
   def test_rollback_does_not_modify
     fb = Factbase.new
     fb.insert.foo = 42


### PR DESCRIPTION
`@copies` is keyed by identity, but `Hash#key` searches the values with `==`, so
`source_of` returned the wrong original whenever two facts held equal
properties. Modifying both in one transaction put a single original in the
garbage set and the factbase grew by one stale fact; deleting both appended the
same object id twice and `uniq` collapsed it into one deletion.

A second identity-keyed map from copy to original is kept now, so the lookup is
by identity in both directions. This is the same root cause as #715, so both
cases are covered here and tested.

Closes #714
Closes #715
