### PR TITLE
#717: give a transaction its own cache

### DIFF
--- a/lib/factbase/cached/cached_factbase.rb
+++ b/lib/factbase/cached/cached_factbase.rb
@@ -58,7 +58,9 @@ class Factbase::CachedFactbase
   # @return [Factbase::Churn] How many facts have been changed (zero if rolled back)
   def txn
     @origin.txn do |fbt|
-      yield(Factbase::CachedFactbase.new(fbt, @cache))
+      yield(Factbase::CachedFactbase.new(fbt, {}))
     end
+  ensure
+    @cache.clear
   end
 end

--- a/test/factbase/cached/test_cached_factbase.rb
+++ b/test/factbase/cached/test_cached_factbase.rb
@@ -84,4 +84,16 @@ class TestCachedFactbase < Factbase::Test
     end
     assert_equal(2, fb.query('(always)').each.to_a.size)
   end
+
+  def test_query_after_rollback_forgets_the_facts
+    fb = Factbase::CachedFactbase.new(Factbase.new)
+    fb.insert.foo = 'kept'
+    fb.txn do |fbt|
+      fbt.insert.foo = 'ghost'
+      fbt.query('(exists foo)').each.to_a
+      raise(Factbase::Rollback)
+    end
+    assert_equal(1, fb.size)
+    assert_equal(['kept'], fb.query('(exists foo)').each.to_a.map(&:foo))
+  end
 end


### PR DESCRIPTION
The factbase built for a transaction shared the outer cache, so a query run
inside the transaction consumed the dirty flag and stored its result under the
query key. After a rollback the next query outside served that array, holding a
fact that was never committed.

The transaction gets its own cache now, and the outer one is dropped when the
transaction ends, committed or not.

Closes #717
