### PR TITLE
#718: keep a fact fresh until the index has seen it

### DIFF
--- a/lib/factbase/indexed/indexed_factbase.rb
+++ b/lib/factbase/indexed/indexed_factbase.rb
@@ -52,10 +52,7 @@ class Factbase::IndexedFactbase
   # @param [Array<Hash>] maps Possible maps to use
   def query(term, maps = nil)
     term = to_term(term) if term.is_a?(String)
-    q = @origin.query(term, maps)
-    q = Factbase::IndexedQuery.new(q, @idx, self, @fresh)
-    @fresh.clear
-    q
+    Factbase::IndexedQuery.new(@origin.query(term, maps), @idx, self, @fresh)
   end
 
   # Run an ACID transaction.

--- a/lib/factbase/indexed/indexed_query.rb
+++ b/lib/factbase/indexed/indexed_query.rb
@@ -38,7 +38,7 @@ class Factbase::IndexedQuery
   def each(fb = @fb, params = {})
     return to_enum(__method__, fb, params) unless block_given?
     n = 0
-    @origin.each(fb, params).to_a.each do |f|
+    @origin.each(fb, params).to_a.tap { @fresh.clear }.each do |f|
       yield(Factbase::IndexedFact.new(f, @idx, @fresh))
       n += 1
     end
@@ -50,13 +50,16 @@ class Factbase::IndexedQuery
   # @param [Hash] params Optional params accessible in the query via the "$" symbol
   # @return [String|Integer|Float|Time|Array|NilClass] The value evaluated
   def one(fb = @fb, params = {})
-    @origin.one(fb, params)
+    @origin.one(fb, params).tap { @fresh.clear }
   end
 
   # Delete all facts that match the query.
   # @param [Factbase] fb The factbase
   # @return [Integer] Total number of facts deleted
   def delete!(fb = @fb)
-    @origin.delete!(fb).tap { @idx.clear }
+    @origin.delete!(fb).tap do
+      @idx.clear
+      @fresh.clear
+    end
   end
 end

--- a/test/factbase/indexed/test_incremental_indexing.rb
+++ b/test/factbase/indexed/test_incremental_indexing.rb
@@ -51,6 +51,18 @@ class TestIncrementalIndexing < Factbase::Test
     assert_empty(fb.query('(eq foo 44)').each.to_a)
   end
 
+  def test_fact_stays_fresh_until_the_query_runs
+    fb = Factbase::IndexedFactbase.new(Factbase.new)
+    fb.insert.foo = 1
+    fb.query('(exists bar)').then do |query|
+      fb.insert.then do |f|
+        query.each.to_a
+        f.bar = 2
+      end
+    end
+    assert_equal(1, fb.query('(exists bar)').each.to_a.size)
+  end
+
   def test_transaction_clears_index_on_delete
     idx = {}
     fb = Factbase::IndexedFactbase.new(Factbase.new, idx)


### PR DESCRIPTION
`@fresh` was cleared when the query object was built, before the index was fed.
A fact inserted after that, but before the query ran, went into the index without
its properties and stayed marked fresh, so its later property write did not
invalidate the index and every later query answered from a stale one.

The set is cleared where the index is actually built and iterated now.

Closes #718
