### PR TITLE
#719: print a value XML cannot hold in Base64

### DIFF
--- a/lib/factbase/to_xml.rb
+++ b/lib/factbase/to_xml.rb
@@ -16,10 +16,16 @@ require_relative '../factbase/flatten'
 #  fb = Factbase.new
 #  puts Factbase::ToXML.new(fb).xml
 #
+# A value holding a character that XML 1.0 cannot represent is printed
+# in Base64 and marked with t="B", since printing it verbatim would make
+# the document not well-formed.
+#
 # Author:: Yegor Bugayenko (yegor256@gmail.com)
 # Copyright:: Copyright (c) 2024-2026 Yegor Bugayenko
 # License:: MIT
 class Factbase::ToXML
+  BAD = /[^\u0009\u000A\u000D\u0020-\uD7FF\uE000-\uFFFD\u{10000}-\u{10FFFF}]/
+
   # Constructor.
   def initialize(fb, sorter = '_id')
     @fb = fb
@@ -38,11 +44,11 @@ class Factbase::ToXML
               if vv.is_a?(Array)
                 xml.__send__(:"#{k}_") do
                   vv.each do |v|
-                    xml.__send__(:v, to_str(v), t: type_of(v))
+                    put(xml, :v, v)
                   end
                 end
               else
-                xml.__send__(:"#{k}_", to_str(vv), t: type_of(vv))
+                put(xml, :"#{k}_", vv)
               end
             end
           end
@@ -52,6 +58,18 @@ class Factbase::ToXML
   end
 
   private
+
+  # Put one value into the document, in Base64 if XML cannot hold it verbatim.
+  # @param [Nokogiri::XML::Builder] xml The builder
+  # @param [Symbol] name The name of the element
+  # @param [Object] val The value
+  def put(xml, name, val)
+    if val.is_a?(String) && val.match?(BAD)
+      xml.__send__(name, [val].pack('m0'), t: 'B')
+    else
+      xml.__send__(name, to_str(val), t: type_of(val))
+    end
+  end
 
   def to_str(val)
     if val.is_a?(Time)

--- a/test/factbase/test_to_xml.rb
+++ b/test/factbase/test_to_xml.rb
@@ -21,6 +21,14 @@ class TestToXML < Factbase::Test
     assert_match(/^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$/, xml.xpath('/fb/f/t/text()').text)
   end
 
+  def test_control_character_rendering
+    fb = Factbase.new
+    fb.insert.t = "a#{1.chr}b"
+    node = Nokogiri::XML.parse(Factbase::ToXML.new(fb).xml, &:strict).xpath('/fb/f/t').first
+    assert_equal('B', node['t'])
+    assert_equal("a#{1.chr}b", node.text.unpack1('m0'))
+  end
+
   def test_complex_rendering
     fb = Factbase.new
     fb.insert.t = "\uffff < > & ' \""


### PR DESCRIPTION
A fact can hold a string with a C0 control character, and the builder copied it
into the document verbatim. XML 1.0 forbids those, so a strict reparse failed
and a lenient one dropped the byte, changing the value.

Such a value is printed in Base64 now and marked with `t="B"`, so the document is
always well-formed and the value survives.

Closes #719
