### PR TITLE
#741: keep a non-term operand inside the term

### DIFF
--- a/lib/factbase/terms/and.rb
+++ b/lib/factbase/terms/and.rb
@@ -29,7 +29,7 @@ class Factbase::And < Factbase::TermBase
 
   def simplify
     unique = Factbase::Simplified.new(@operands).unique
-    return unique[0] if unique.size == 1
+    return unique[0] if unique.size == 1 && (unique[0].is_a?(Factbase::Term) || unique[0].is_a?(Factbase::TermBase))
     Factbase::Term.new(@op, unique)
   end
 end

--- a/lib/factbase/terms/or.rb
+++ b/lib/factbase/terms/or.rb
@@ -29,7 +29,7 @@ class Factbase::Or < Factbase::TermBase
 
   def simplify
     unique = Factbase::Simplified.new(@operands).unique
-    return unique[0] if unique.size == 1
+    return unique[0] if unique.size == 1 && (unique[0].is_a?(Factbase::Term) || unique[0].is_a?(Factbase::TermBase))
     Factbase::Term.new(@op, unique)
   end
 end

--- a/test/factbase/terms/test_and.rb
+++ b/test/factbase/terms/test_and.rb
@@ -24,4 +24,13 @@ class TestAnd < Factbase::Test
   def test_parses_a_non_term_operand
     assert_equal(%((and (eq a 1) 5)), Factbase::Syntax.new(%((and (eq a 1) 5))).to_term.to_s)
   end
+
+  def test_reports_a_single_non_term_operand
+    fb = Factbase.new
+    fb.insert.name = 'alice'
+    ['(and 42)', '(or 42)'].each do |q|
+      e = assert_raises(StandardError, q) { fb.query(q).each.to_a }
+      assert_includes(e.message, 'Boolean is expected, while Integer received from 42', q)
+    end
+  end
 end

--- a/test/factbase/terms/test_and.rb
+++ b/test/factbase/terms/test_and.rb
@@ -29,8 +29,11 @@ class TestAnd < Factbase::Test
     fb = Factbase.new
     fb.insert.name = 'alice'
     ['(and 42)', '(or 42)'].each do |q|
-      e = assert_raises(StandardError, q) { fb.query(q).each.to_a }
-      assert_includes(e.message, 'Boolean is expected, while Integer received from 42', q)
+      assert_includes(
+        assert_raises(StandardError, q) do
+          fb.query(q).each.to_a
+        end.message, 'Boolean is expected, while Integer received from 42', q
+      )
     end
   end
 end


### PR DESCRIPTION
`simplify` returned the operand itself when only one was left, so `(and 42)` became the bare `42` and the query then called `predict` on an Integer. It only collapses now when the remaining operand is a term, so `(and 42)` reports `Boolean is expected, while Integer received from 42`, the same as `(and (always) 42)`.

Closes #741
