### PR TITLE
#742: check that when gets terms

### DIFF
--- a/lib/factbase/terms/when.rb
+++ b/lib/factbase/terms/when.rb
@@ -22,6 +22,11 @@ class Factbase::When < Factbase::TermBase
   # @return [Boolean] True if first operand is false OR both are true
   def evaluate(fact, maps, fb)
     assert_args(2)
+    @operands.each do |o|
+      unless o.is_a?(Factbase::Term) || o.is_a?(Factbase::TermBase)
+        raise(ArgumentError, "A term is expected, but '#{o}' provided")
+      end
+    end
     return true unless @operands[0].evaluate(fact, maps, fb)
     @operands[1].evaluate(fact, maps, fb)
   end

--- a/test/factbase/terms/test_when.rb
+++ b/test/factbase/terms/test_when.rb
@@ -38,8 +38,11 @@ class TestWhen < Factbase::Test
     fb = Factbase.new
     fb.insert.foo = 42
     ['(when 42 (always))', '(when (always) 42)'].each do |q|
-      e = assert_raises(StandardError, q) { fb.query(q).each.to_a }
-      assert_includes(e.message, "A term is expected, but '42' provided", q)
+      assert_includes(
+        assert_raises(StandardError, q) do
+          fb.query(q).each.to_a
+        end.message, "A term is expected, but '42' provided", q
+      )
     end
   end
 end

--- a/test/factbase/terms/test_when.rb
+++ b/test/factbase/terms/test_when.rb
@@ -33,4 +33,13 @@ class TestWhen < Factbase::Test
       refute(Factbase::When.new([first, second]).evaluate(fact({ 'foo' => 22, 'bar' => 42 }), [], Factbase.new), msg)
     end
   end
+
+  def test_rejects_a_non_term_operand
+    fb = Factbase.new
+    fb.insert.foo = 42
+    ['(when 42 (always))', '(when (always) 42)'].each do |q|
+      e = assert_raises(StandardError, q) { fb.query(q).each.to_a }
+      assert_includes(e.message, "A term is expected, but '42' provided", q)
+    end
+  end
 end


### PR DESCRIPTION
`when` called `evaluate` on its operands without checking them, so a literal produced `Probably the term 'when' is not defined`, which blames a missing term instead of the bad operand. It now raises `A term is expected, but '42' provided`, the way `agg` and `assert` do.

Closes #742
