### PR TITLE
#743: forget what unique saw on the previous run

### DIFF
--- a/lib/factbase/query.rb
+++ b/lib/factbase/query.rb
@@ -45,6 +45,7 @@ class Factbase::Query
   def each(fb = @fb, params = {})
     return to_enum(__method__, fb, params) unless block_given?
     yielded = 0
+    @term.reset if @term.respond_to?(:reset)
     params = params.transform_keys(&:to_s) if params.is_a?(Hash)
     maybe = @term.predict(@maps, fb, Factbase::Tee.new({}, params))
     maybe ||= @maps unless maybe.equal?(@maps)

--- a/lib/factbase/term.rb
+++ b/lib/factbase/term.rb
@@ -173,11 +173,10 @@ class Factbase::Term < Factbase::TermBase
   end
 
   # Forget what previous iterations of this term have seen.
-  # @return [nil]
+  # @return [Array, nil] The operands that were walked
   def reset
     @terms[@op].reset if @terms.key?(@op) && @terms[@op].respond_to?(:reset)
     @operands&.each { |o| o.reset if o.respond_to?(:reset) }
-    nil
   end
 
   # Try to predict which facts from the provided list

--- a/lib/factbase/term.rb
+++ b/lib/factbase/term.rb
@@ -172,6 +172,14 @@ class Factbase::Term < Factbase::TermBase
     end
   end
 
+  # Forget what previous iterations of this term have seen.
+  # @return [nil]
+  def reset
+    @terms[@op].reset if @terms.key?(@op) && @terms[@op].respond_to?(:reset)
+    @operands&.each { |o| o.reset if o.respond_to?(:reset) }
+    nil
+  end
+
   # Try to predict which facts from the provided list
   # should be evaluated. If no prediction can be made,
   # the same list is returned.

--- a/lib/factbase/terms/base.rb
+++ b/lib/factbase/terms/base.rb
@@ -29,6 +29,13 @@ class Factbase::TermBase
       end
   end
 
+  # Forget what previous iterations of this term have seen.
+  # @return [nil]
+  def reset
+    @operands&.each { |o| o.reset if o.respond_to?(:reset) }
+    nil
+  end
+
   private
 
   def assert_args(num)

--- a/lib/factbase/terms/base.rb
+++ b/lib/factbase/terms/base.rb
@@ -30,10 +30,9 @@ class Factbase::TermBase
   end
 
   # Forget what previous iterations of this term have seen.
-  # @return [nil]
+  # @return [Array, nil] The operands that were walked
   def reset
     @operands&.each { |o| o.reset if o.respond_to?(:reset) }
-    nil
   end
 
   private

--- a/lib/factbase/terms/unique.rb
+++ b/lib/factbase/terms/unique.rb
@@ -14,6 +14,13 @@ class Factbase::Unique < Factbase::TermBase
     @operands = operands
   end
 
+  # Forget the tuples seen by the previous iteration.
+  # @return [nil]
+  def reset
+    @seen = nil
+    super
+  end
+
   # Evaluate term on a fact.
   # @param [Factbase::Fact] fact The fact
   # @param [Array<Factbase::Fact>] maps All maps available

--- a/lib/factbase/terms/unique.rb
+++ b/lib/factbase/terms/unique.rb
@@ -15,7 +15,7 @@ class Factbase::Unique < Factbase::TermBase
   end
 
   # Forget the tuples seen by the previous iteration.
-  # @return [nil]
+  # @return [Array, nil] The operands that were walked
   def reset
     @seen = nil
     super

--- a/test/factbase/terms/test_unique.rb
+++ b/test/factbase/terms/test_unique.rb
@@ -46,4 +46,13 @@ class TestUnique < Factbase::Test
     assert(t.evaluate(fact('foo' => 2, 'bar' => 'x', 'baz' => true), [], Factbase.new))
     refute(t.evaluate(fact('foo' => 1, 'bar' => 'x', 'baz' => true), [], Factbase.new))
   end
+
+  def test_repeats_on_the_second_run
+    fb = Factbase.new
+    fb.insert.name = 'alice'
+    fb.insert.name = 'bob'
+    q = fb.query('(unique name)')
+    assert_equal(2, q.each.to_a.size)
+    assert_equal(2, q.each.to_a.size)
+  end
 end


### PR DESCRIPTION
`unique` kept `@seen` in the term, so a second `each` on the same query object rejected everything and returned nothing. Terms get a `reset` that walks the operand tree, `unique` drops `@seen` in it, and `Query#each` calls it before iterating, so a query object gives the same facts every time.

Closes #743
