### PR TITLE
#744: name the conversion terms as they are

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,8 +201,8 @@ It's possible to add and deduct string values to time values, like
 
 Types may be converted:
 
-* `(to_int v)` is an integer of `v`
-* `(to_str v)` is a string of `v`
+* `(to_integer v)` is an integer of `v`
+* `(to_string v)` is a string of `v`
 * `(to_float v)` is a float of `v`
 
 One term is for meta-programming:

--- a/test/test_readme.rb
+++ b/test/test_readme.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+require_relative '../lib/factbase'
+require_relative '../lib/factbase/term'
+require_relative 'test__helper'
+
+# Test for the README.
+# Author:: Yegor Bugayenko (yegor256@gmail.com)
+# Copyright:: Copyright (c) 2024-2026 Yegor Bugayenko
+# License:: MIT
+class TestReadme < Factbase::Test
+  def test_every_documented_term_exists
+    term = Factbase::Term.new(:always, [])
+    known = term.instance_variable_get(:@terms).keys.map(&:to_s)
+    File.readlines(File.join(__dir__, '../README.md')).each do |line|
+      next unless line.start_with?('* `(')
+      op = line[4..].split(/[\s)`]/).first
+      assert(
+        known.include?(op) || term.respond_to?(op.to_sym, true),
+        "The term '#{op}' is documented in README.md, but does not exist"
+      )
+    end
+  end
+end


### PR DESCRIPTION
The README listed `(to_int v)` and `(to_str v)`, but the terms are `to_integer` and `to_string`, so the documented spelling always failed. Renamed both, and added a test that walks the term bullets in the README and checks each one exists.

Closes #744
