### PR TITLE
#746: say which value cannot be summed

### DIFF
--- a/lib/factbase/terms/sum.rb
+++ b/lib/factbase/terms/sum.rb
@@ -31,6 +31,9 @@ class Factbase::Sum < Factbase::TermBase
       next if vv.nil?
       vv = [vv] unless vv.respond_to?(:to_a)
       vv.each do |v|
+        unless v.is_a?(Integer) || v.is_a?(Float)
+          raise(ArgumentError, "The value '#{v}' of the '#{k}' property is not a number, can't sum it up")
+        end
         sum += v
       end
     end

--- a/test/factbase/terms/test_sum.rb
+++ b/test/factbase/terms/test_sum.rb
@@ -41,7 +41,10 @@ class TestSum < Factbase::Test
   def test_names_the_property_and_the_value
     fb = Factbase.new
     fb.insert.name = 'alice'
-    e = assert_raises(StandardError) { fb.query('(gt (sum name) 0)').each.to_a }
-    assert_includes(e.message, "The value 'alice' of the 'name' property is not a number")
+    assert_includes(
+      assert_raises(StandardError) do
+        fb.query('(gt (sum name) 0)').each.to_a
+      end.message, "The value 'alice' of the 'name' property is not a number"
+    )
   end
 end

--- a/test/factbase/terms/test_sum.rb
+++ b/test/factbase/terms/test_sum.rb
@@ -37,4 +37,11 @@ class TestSum < Factbase::Test
       "Too many (2) operands for 'sum' (1 expected)"
     )
   end
+
+  def test_names_the_property_and_the_value
+    fb = Factbase.new
+    fb.insert.name = 'alice'
+    e = assert_raises(StandardError) { fb.query('(gt (sum name) 0)').each.to_a }
+    assert_includes(e.message, "The value 'alice' of the 'name' property is not a number")
+  end
 end


### PR DESCRIPTION
`sum` added every value with `+` and let Ruby's `String can't be coerced into Integer` out, naming neither the property nor the value, so on a large factbase there was no way to tell which fact was wrong. It now raises `The value 'alice' of the 'name' property is not a number, can't sum it up`.

Closes #746
