### PR TITLE
#747: report which two values cannot be compared

### DIFF
--- a/lib/factbase/terms/best.rb
+++ b/lib/factbase/terms/best.rb
@@ -17,7 +17,18 @@ class Factbase::Best
       next if vv.nil?
       vv = [vv] unless vv.respond_to?(:to_a)
       vv.each do |v|
-        best = v if best.nil? || @criteria.call(v, best)
+        if best.nil?
+          best = v
+          next
+        end
+        begin
+          best = v if @criteria.call(v, best)
+        rescue ArgumentError, TypeError
+          raise(
+            ArgumentError,
+            "Can't compare '#{v}' (#{v.class}) with '#{best}' (#{best.class}) in the '#{key}' property"
+          )
+        end
       end
     end
     best

--- a/test/factbase/terms/test_max.rb
+++ b/test/factbase/terms/test_max.rb
@@ -38,4 +38,14 @@ class TestMax < Factbase::Test
       )
     )
   end
+
+  def test_reports_incomparable_values
+    fb = Factbase.new
+    fb.insert.v = 's'
+    fb.insert.v = 1
+    ['(gt (max v) 0)', '(gt (min v) 0)'].each do |q|
+      e = assert_raises(StandardError, q) { fb.query(q).each.to_a }
+      assert_includes(e.message, "Can't compare '1' (Integer) with 's' (String) in the 'v' property", q)
+    end
+  end
 end

--- a/test/factbase/terms/test_max.rb
+++ b/test/factbase/terms/test_max.rb
@@ -44,8 +44,11 @@ class TestMax < Factbase::Test
     fb.insert.v = 's'
     fb.insert.v = 1
     ['(gt (max v) 0)', '(gt (min v) 0)'].each do |q|
-      e = assert_raises(StandardError, q) { fb.query(q).each.to_a }
-      assert_includes(e.message, "Can't compare '1' (Integer) with 's' (String) in the 'v' property", q)
+      assert_includes(
+        assert_raises(StandardError, q) do
+          fb.query(q).each.to_a
+        end.message, "Can't compare '1' (Integer) with 's' (String) in the 'v' property", q
+      )
     end
   end
 end


### PR DESCRIPTION
`max` and `min` compared with `>` and `<` and let `comparison of Integer with String failed` out, which says nothing about the property or the values. The comparison is wrapped now and reports `Can't compare '1' (Integer) with 's' (String) in the 'v' property`.

Closes #747
