### PR TITLE
#748: let a fact hold a boolean

### DIFF
--- a/lib/factbase/fact.rb
+++ b/lib/factbase/fact.rb
@@ -57,7 +57,7 @@ class Factbase::Fact
       raise(ArgumentError, "The value of '#{kk}' can't be empty") if v == ''
       raise(ArgumentError, "The type '#{v.class}' of '#{kk}' is not allowed") unless [
         String, Integer, Float,
-        Time
+        Time, TrueClass, FalseClass
       ].include?(v.class)
       v = v.utc if v.is_a?(Time)
       @map[kk] = [] if @map[kk].nil?

--- a/test/factbase/test_fact.rb
+++ b/test/factbase/test_fact.rb
@@ -105,4 +105,16 @@ class TestFact < Factbase::Test
     f.foo = 42
     assert_includes(f.all_properties, 'foo')
   end
+
+  def test_stores_booleans
+    fb = Factbase.new
+    f = fb.insert
+    f.yes = true
+    f.no = false
+    assert_equal([true], f['yes'])
+    assert_equal([false], f['no'])
+    fresh = Factbase.new
+    fresh.import(fb.export)
+    assert_equal([true], fresh.query('(exists yes)').each.to_a.first['yes'])
+  end
 end


### PR DESCRIPTION
The operand whitelist in `_values` allowed `TrueClass` and `FalseClass` while `Fact` refused both, so the two lists that spell out the allowed scalar types disagreed. `Fact` takes booleans now, which is the side that can change: dropping them from `_values` breaks `and` and `or`, whose operands are terms that evaluate to booleans.

Closes #748
