### PR TITLE
#749: say the input is not a factbase

### DIFF
--- a/lib/factbase.rb
+++ b/lib/factbase.rb
@@ -253,12 +253,12 @@ class Factbase
   # @param [String] bytes Binary string to import
   def import(bytes)
     raise(StandardError, 'Empty input, cannot load a factbase') if bytes.empty?
-    data = Marshal.load(bytes)
-    @maps +=
-      if data.is_a?(Hash) && data.key?(:maps)
-        Marshal.load(data[:maps])
-      else
-        data
-      end
+    begin
+      data = Marshal.load(bytes)
+      data = Marshal.load(data[:maps]) if data.is_a?(Hash) && data.key?(:maps)
+    rescue TypeError, ArgumentError => e
+      raise(StandardError, "The input is not a valid factbase: #{e.message}")
+    end
+    @maps += data
   end
 end

--- a/test/test_factbase.rb
+++ b/test/test_factbase.rb
@@ -480,4 +480,14 @@ class TestFactbase < Factbase::Test
       assert_equal("Can't find 'bar' attribute out of [foo]", assert_raises(StandardError) { f.bar }.message)
     end
   end
+
+  def test_import_of_corrupt_data
+    good = Factbase.new
+    good.insert.a = 1
+    data = good.export
+    ['this is not a factbase', data[0..(data.size / 2)]].each do |bytes|
+      e = assert_raises(StandardError) { Factbase.new.import(bytes) }
+      assert_includes(e.message, 'The input is not a valid factbase')
+    end
+  end
 end

--- a/test/test_factbase.rb
+++ b/test/test_factbase.rb
@@ -486,8 +486,11 @@ class TestFactbase < Factbase::Test
     good.insert.a = 1
     data = good.export
     ['this is not a factbase', data[0..(data.size / 2)]].each do |bytes|
-      e = assert_raises(StandardError) { Factbase.new.import(bytes) }
-      assert_includes(e.message, 'The input is not a valid factbase')
+      assert_includes(
+        assert_raises(StandardError) do
+          Factbase.new.import(bytes)
+        end.message, 'The input is not a valid factbase'
+      )
     end
   end
 end


### PR DESCRIPTION
`import` guarded empty input but let `Marshal`'s own errors out for corrupt or truncated bytes, so a caller reading a half-written file got `marshal data too short` with nothing about a factbase in it. Both are wrapped now, the way the empty case already was.

Closes #749
