### PR TITLE
#750: say a duration needs a whole number

### DIFF
--- a/lib/factbase/terms/arithmetic.rb
+++ b/lib/factbase/terms/arithmetic.rb
@@ -33,7 +33,11 @@ class Factbase::Arithmetic < Factbase::TermBase
     r = rights[0]
     if v.is_a?(Time) && r.is_a?(String)
       (num, units) = r.split
-      num = Integer(num, 10)
+      begin
+        num = Integer(num, 10)
+      rescue ArgumentError, TypeError
+        raise(ArgumentError, "Amount '#{num}' in '#{r}' must be a whole number")
+      end
       r =
         case units
         when 'seconds', 'second'

--- a/test/factbase/terms/test_minus.rb
+++ b/test/factbase/terms/test_minus.rb
@@ -35,4 +35,15 @@ class TestMinus < Factbase::Test
     )
     assert_nil(t.evaluate(fact, [], Factbase.new))
   end
+
+  def test_rejects_a_fractional_duration
+    fb = Factbase.new
+    fb.insert.when = Time.now
+    ['1.5 hours', 'abc hours'].each do |d|
+      e = assert_raises(StandardError, d) do
+        fb.query("(gt when (minus (to_time '2026-09-04T07:40:32Z') '#{d}'))").each.to_a
+      end
+      assert_includes(e.message, %(must be a whole number), d)
+    end
+  end
 end

--- a/test/factbase/terms/test_minus.rb
+++ b/test/factbase/terms/test_minus.rb
@@ -40,10 +40,11 @@ class TestMinus < Factbase::Test
     fb = Factbase.new
     fb.insert.when = Time.now
     ['1.5 hours', 'abc hours'].each do |d|
-      e = assert_raises(StandardError, d) do
-        fb.query("(gt when (minus (to_time '2026-09-04T07:40:32Z') '#{d}'))").each.to_a
-      end
-      assert_includes(e.message, %(must be a whole number), d)
+      assert_includes(
+        assert_raises(StandardError, d) do
+          fb.query("(gt when (minus (to_time '2026-09-04T07:40:32Z') '#{d}'))").each.to_a
+        end.message, 'must be a whole number', d
+      )
     end
   end
 end


### PR DESCRIPTION
A duration like `1.5 hours` failed with `invalid value for Integer(): "1.5"`, which says nothing about durations and does not show the string that was rejected. It now raises `Amount '1.5' in '1.5 hours' must be a whole number`, next to the unit check that was already there.

Closes #750
