### PR TITLE
#751: print the term, not the object graph

### DIFF
--- a/lib/factbase/query.rb
+++ b/lib/factbase/query.rb
@@ -54,7 +54,7 @@ class Factbase::Query
       f = Factbase::Tee.new(f, params)
       r = @term.evaluate(Factbase::Accum.new(f, extras, false), @maps, fb)
       unless r.is_a?(TrueClass) || r.is_a?(FalseClass)
-        raise(ArgumentError, "Unexpected evaluation result of type #{r.class}, must be Boolean at #{@term.inspect}")
+        raise(ArgumentError, "Unexpected evaluation result of type #{r.class}, must be Boolean at #{@term}")
       end
       next unless r
       yield(Factbase::Accum.new(f, extras, true))
@@ -71,7 +71,7 @@ class Factbase::Query
     params = params.transform_keys(&:to_s) if params.is_a?(Hash)
     r = @term.evaluate(Factbase::Tee.new(Factbase::Fact.new({}), params), @maps, fb)
     unless %w[String Integer Float Time Array NilClass].include?(r.class.to_s)
-      raise(StandardError, "Incorrect type #{r.class} returned by #{@term.inspect}")
+      raise(StandardError, "Incorrect type #{r.class} returned by #{@term}")
     end
     r
   end

--- a/test/factbase/test_query.rb
+++ b/test/factbase/test_query.rb
@@ -367,6 +367,13 @@ class TestQuery < Factbase::Test
     assert_equal(0, fb.size)
   end
 
+  def test_error_names_the_term_not_the_object
+    fb = Factbase.new
+    fb.insert.what = 'issue'
+    e = assert_raises(StandardError) { fb.query('(eq what "issue")').one }
+    assert_equal("Incorrect type FalseClass returned by (eq what 'issue')", e.message)
+  end
+
   private
 
   def with_factbases(maps = [], &)

--- a/test/factbase/test_query.rb
+++ b/test/factbase/test_query.rb
@@ -371,9 +371,8 @@ class TestQuery < Factbase::Test
     fb = Factbase.new
     fb.insert.what = 'issue'
     assert_equal(
-      "Incorrect type FalseClass returned by (eq what 'issue')", assert_raises(StandardError) do
-                                                                   fb.query('(eq what "issue")').one
-                                                                 end.message
+      "Incorrect type FalseClass returned by (eq what 'issue')",
+      assert_raises(StandardError) { fb.query('(eq what "issue")').one }.message
     )
   end
 

--- a/test/factbase/test_query.rb
+++ b/test/factbase/test_query.rb
@@ -370,8 +370,11 @@ class TestQuery < Factbase::Test
   def test_error_names_the_term_not_the_object
     fb = Factbase.new
     fb.insert.what = 'issue'
-    e = assert_raises(StandardError) { fb.query('(eq what "issue")').one }
-    assert_equal("Incorrect type FalseClass returned by (eq what 'issue')", e.message)
+    assert_equal(
+      "Incorrect type FalseClass returned by (eq what 'issue')", assert_raises(StandardError) do
+                                                                   fb.query('(eq what "issue")').one
+                                                                 end.message
+    )
   end
 
   private


### PR DESCRIPTION
The two error messages in `query.rb` used `@term.inspect`, which dumps the whole object graph: a five-kilobyte message for `(eq what 'issue')` and 1.1 MB for a three-clause `and`. They interpolate the term itself now, like the rest of the gem does.

Closes #751
