### PR TITLE
#768: give a parameter name the same rule as a property name

### DIFF
--- a/lib/factbase/syntax.rb
+++ b/lib/factbase/syntax.rb
@@ -146,7 +146,7 @@ class Factbase::Syntax
       elsif t.match?(/^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$/)
         Time.parse(t)
       else
-        raise(ArgumentError, "Wrong symbol format (#{t})") unless t.match?(/^([_a-z][a-zA-Z0-9_]*|\$[_a-z]+)$/)
+        raise(ArgumentError, "Wrong symbol format (#{t})") unless t.match?(/^\$?[_a-z][a-zA-Z0-9_]*$/)
         t.to_sym
       end
     end

--- a/test/factbase/test_query.rb
+++ b/test/factbase/test_query.rb
@@ -315,10 +315,11 @@ class TestQuery < Factbase::Test
   end
 
   def test_with_a_digit_in_the_param_name
-    maps = [{ 'foo' => [42] }, { 'foo' => [17] }]
     assert_equal(
       1,
-      Factbase::Query.new(maps, '(eq foo $bar2)', Factbase.new).each(Factbase.new, bar2: [42]).to_a.size
+      Factbase::Query.new(
+        [{ 'foo' => [42] }, { 'foo' => [17] }], '(eq foo $bar2)', Factbase.new
+      ).each(Factbase.new, bar2: [42]).to_a.size
     )
   end
 

--- a/test/factbase/test_query.rb
+++ b/test/factbase/test_query.rb
@@ -314,6 +314,14 @@ class TestQuery < Factbase::Test
     assert_equal(0, Factbase::Query.new(maps, '(eq foo $bar)', Factbase.new).each(Factbase.new, bar: [555]).to_a.size)
   end
 
+  def test_with_a_digit_in_the_param_name
+    maps = [{ 'foo' => [42] }, { 'foo' => [17] }]
+    assert_equal(
+      1,
+      Factbase::Query.new(maps, '(eq foo $bar2)', Factbase.new).each(Factbase.new, bar2: [42]).to_a.size
+    )
+  end
+
   def test_with_nil_alias
     assert_nil(Factbase::Query.new([{ 'foo' => [42] }], '(as bar (plus xxx 3))', Factbase.new).each.to_a[0]['bar'])
   end


### PR DESCRIPTION
The symbol pattern let a property name hold digits and capitals (`[_a-z][a-zA-Z0-9_]*`)
but a parameter name only lowercase letters and underscores (`\$[_a-z]+`), so `(eq id2 $id)`
parsed and `(eq id2 $id2)` did not.

Both branches are now one pattern with an optional leading `$`.

Closes #768
