### PR TITLE
#769: take a time literal with fractional seconds

### DIFF
--- a/lib/factbase/syntax.rb
+++ b/lib/factbase/syntax.rb
@@ -143,7 +143,7 @@ class Factbase::Syntax
         Integer(t, 10)
       elsif t.match?(/^(\+|-)?[0-9]+\.[0-9]+(e(\+|-)[0-9]+)?$/)
         Float(t)
-      elsif t.match?(/^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$/)
+      elsif t.match?(/^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(\.[0-9]+)?Z$/)
         Time.parse(t)
       else
         raise(ArgumentError, "Wrong symbol format (#{t})") unless t.match?(/^([_a-z][a-zA-Z0-9_]*|\$[_a-z]+)$/)

--- a/test/factbase/test_syntax.rb
+++ b/test/factbase/test_syntax.rb
@@ -99,6 +99,15 @@ class TestSyntax < Factbase::Test
     assert(Factbase::Syntax.new('(eq t 1.5e-10)').to_term.evaluate({ 't' => 1.5e-10 }, [], Factbase.new))
   end
 
+  def test_parses_a_time_with_fractional_seconds
+    t = Time.parse('2026-09-05T07:00:00.123456Z')
+    assert(
+      Factbase::Syntax.new("(eq when #{t.utc.iso8601(6)})").to_term.evaluate(
+        { 'when' => [t] }, [], Factbase.new
+      )
+    )
+  end
+
   def test_simple_matching
     m = { 'foo' => ['Hello, world!'], 'bar' => [42], 'z' => [1, 2, 3, 4] }
     {


### PR DESCRIPTION
The time pattern in the tokenizer had no room for the fractional part, so
`2026-09-05T07:00:00.123456Z` was refused as a wrong symbol format. That is the shape
`ToXML` and `ToJSON` write (`iso8601(6)`), so a time taken out of the gem's own output
could not be pasted back into a query.

The fraction is now optional in the pattern; `Time.parse` already reads it.

Closes #769
