### PR TITLE
#770: list a shared property name once

### DIFF
--- a/lib/factbase/tee.rb
+++ b/lib/factbase/tee.rb
@@ -27,7 +27,7 @@ class Factbase::Tee
   end
 
   def all_properties
-    (@fact.is_a?(Hash) ? @fact.keys : @fact.all_properties) +
+    (@fact.is_a?(Hash) ? @fact.keys : @fact.all_properties) |
       (@upper.is_a?(Hash) ? @upper.keys : @upper.all_properties)
   end
 

--- a/test/factbase/test_tee.rb
+++ b/test/factbase/test_tee.rb
@@ -68,8 +68,7 @@ class TestTee < Factbase::Test
     prim = Factbase::Fact.new({})
     prim.foo = 42
     prim.bar = 13
-    t = Factbase::Tee.new(prim, { 'foo' => [9] })
-    assert_equal(%w[foo bar], t.all_properties)
+    assert_equal(%w[foo bar], Factbase::Tee.new(prim, { 'foo' => [9] }).all_properties)
   end
 
   def test_recursively

--- a/test/factbase/test_tee.rb
+++ b/test/factbase/test_tee.rb
@@ -64,6 +64,14 @@ class TestTee < Factbase::Test
     assert_includes(t.all_properties, 'bar')
   end
 
+  def test_all_properties_lists_a_shared_name_once
+    prim = Factbase::Fact.new({})
+    prim.foo = 42
+    prim.bar = 13
+    t = Factbase::Tee.new(prim, { 'foo' => [9] })
+    assert_equal(%w[foo bar], t.all_properties)
+  end
+
   def test_recursively
     prim = Factbase::Fact.new({})
     prim.foo = 42


### PR DESCRIPTION
`Tee#all_properties` concatenated the fact's names with the params' names, so a name held
by both was listed twice. `Accum#all_properties`, which does the same job for a different
pair of sources, uses `|`; this does the same.

Closes #770
