### PR TITLE
#771: rebuild a fact only from the properties it has

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -62,6 +62,7 @@ Elegant/GoodMethodName:
     - '_by_symbol'
     - '_compare'
     - '_feed'
+    - '_flatten'
     - '_init_indexes'
     - '_join'
     - '_resolve'

--- a/lib/factbase/terms/base.rb
+++ b/lib/factbase/terms/base.rb
@@ -37,6 +37,23 @@ class Factbase::TermBase
     raise(ArgumentError, "Too few (#{c}) operands for '#{@op}' (#{num} expected)") if c < num
   end
 
+  # Turns facts into plain maps, keeping only the properties they really carry.
+  #
+  # A fact coming out of a query is a +Factbase::Tee+, whose +all_properties+
+  # also lists the names of the query parameters. Reading such a name back gives
+  # NIL, which is not a value any property may have.
+  #
+  # @param [Array<Factbase::Fact>] facts The facts to turn into maps
+  # @return [Array<Hash>] The maps
+  def _flatten(facts)
+    facts.map do |f|
+      f.all_properties.each_with_object({}) do |k, h|
+        v = f[k]
+        h[k] = v unless v.nil?
+      end
+    end
+  end
+
   def _by_symbol(pos, fact)
     o = @operands[pos]
     raise(ArgumentError, "A symbol expected at ##{pos}, but '#{o}' (#{o.class}) provided") unless o.is_a?(Symbol)

--- a/lib/factbase/terms/head.rb
+++ b/lib/factbase/terms/head.rb
@@ -31,8 +31,6 @@ class Factbase::Head < Factbase::TermBase
     raise(ArgumentError, "A non-negative count is expected by '#{@op}', but #{max} provided") if max.negative?
     term = @operands[1]
     raise(ArgumentError, "A term is expected, but '#{term}' provided") unless term.is_a?(Factbase::Term)
-    fb.query(term, maps).each(fb, params).to_a
-      .take(max)
-      .map! { |m| m.all_properties.to_h { |k| [k, m[k]] } }
+    _flatten(fb.query(term, maps).each(fb, params).to_a.take(max))
   end
 end

--- a/lib/factbase/terms/inverted.rb
+++ b/lib/factbase/terms/inverted.rb
@@ -27,8 +27,6 @@ class Factbase::Inverted < Factbase::TermBase
     assert_args(1)
     term = @operands[0]
     raise(ArgumentError, "A term is expected, but '#{term}' provided") unless term.is_a?(Factbase::Term)
-    fb.query(term, maps).each(fb, params).to_a
-      .reverse
-      .map! { |m| m.all_properties.to_h { |k| [k, m[k]] } }
+    _flatten(fb.query(term, maps).each(fb, params).to_a.reverse)
   end
 end

--- a/lib/factbase/terms/sorted.rb
+++ b/lib/factbase/terms/sorted.rb
@@ -31,7 +31,6 @@ class Factbase::Sorted < Factbase::TermBase
     term = @operands[1]
     raise(ArgumentError, "A term is expected, but '#{term}' provided") unless term.is_a?(Factbase::Term)
     blank, valued = fb.query(term, maps).each(fb, params).to_a.partition { |m| m[prop].nil? }
-    (valued.sort_by { |m| m[prop].first } + blank)
-      .map { |m| m.all_properties.to_h { |k| [k, m[k]] } }
+    _flatten(valued.sort_by { |m| m[prop].first } + blank)
   end
 end

--- a/test/factbase/terms/test_head.rb
+++ b/test/factbase/terms/test_head.rb
@@ -3,6 +3,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2024-2026 Yegor Bugayenko
 # SPDX-License-Identifier: MIT
 
+require_relative '../../../lib/factbase/syntax'
 require_relative '../../../lib/factbase/term'
 require_relative '../../../lib/factbase/terms/head'
 require_relative '../../test__helper'
@@ -18,6 +19,13 @@ class TestHead < Factbase::Test
       2,
       Factbase::Term.new(:head, [2, Factbase::Term.new(:always, [])]).predict(maps, Factbase.new(maps), {}).size
     )
+  end
+
+  def test_does_not_turn_a_param_into_a_property
+    list = Factbase::Syntax.new('(head 1 (eq y $who))').to_term.predict(
+      [{ 'y' => ['first'] }], Factbase.new, { 'who' => ['first'] }
+    )
+    list.each { |m| refute_includes(m.keys, 'who') }
   end
 
   def test_refuses_a_negative_count

--- a/test/factbase/terms/test_inverted.rb
+++ b/test/factbase/terms/test_inverted.rb
@@ -19,4 +19,11 @@ class TestInverted < Factbase::Test
     )
     assert_equal('12 54 33', list.map { |m| m['x'].first }.join(' '))
   end
+
+  def test_does_not_turn_a_param_into_a_property
+    list = Factbase::Syntax.new('(inverted (eq y $who))').to_term.predict(
+      [{ 'y' => ['first'] }], Factbase.new, { 'who' => ['first'] }
+    )
+    list.each { |m| refute_includes(m.keys, 'who') }
+  end
 end

--- a/test/factbase/terms/test_sorted.rb
+++ b/test/factbase/terms/test_sorted.rb
@@ -34,6 +34,14 @@ class TestSorted < Factbase::Test
     assert_equal('first third nothing', list.map { |m| m['y'].first }.join(' '))
   end
 
+  def test_does_not_turn_a_param_into_a_property
+    list = Factbase::Syntax.new('(sorted x (eq y $who))').to_term.predict(
+      [{ 'x' => [8], 'y' => ['first'] }, { 'x' => [1], 'y' => ['second'] }],
+      Factbase.new, { 'who' => %w[first second] }
+    )
+    list.each { |m| refute_includes(m.keys, 'who') }
+  end
+
   def test_join_and_sort
     ff = Factbase.new(
       [


### PR DESCRIPTION
`sorted`, `head` and `inverted` rebuilt every fact from `all_properties`. The facts they
get come out of `Query#each` wrapped in a `Factbase::Tee` together with the query
parameters, so a parameter name ended up in the map with a nil value, which is not
something a property may hold.

The rebuilding is now one place, `_flatten` in `TermBase`, and it skips a name that reads
back as nil. It also removes the same two lines from three terms.

Closes #771
