### PR TITLE
#772: report a thrown rollback as a rollback

### DIFF
--- a/lib/factbase/logged.rb
+++ b/lib/factbase/logged.rb
@@ -52,7 +52,15 @@ class Factbase::Logged
     r =
       @origin.txn do |fbt|
         id = fbt.object_id
-        yield(Factbase::Logged.new(fbt, tube: @tube))
+        commit = false
+        catch(:rollback) do
+          yield(Factbase::Logged.new(fbt, tube: @tube))
+          commit = true
+        end
+        unless commit
+          rollback = true
+          throw(:rollback)
+        end
       rescue Factbase::Rollback => e
         rollback = true
         raise(e)

--- a/test/factbase/test_logged.rb
+++ b/test/factbase/test_logged.rb
@@ -77,6 +77,17 @@ class TestLogged < Factbase::Test
     refute_includes(log.to_s, 'didn\'t touch', log)
   end
 
+  def test_with_txn_thrown_rollback
+    log = Loog::Buffer.new
+    fb = Factbase::Logged.new(Factbase.new, log)
+    fb.txn do |fbt|
+      fbt.insert.foo = 1
+      throw(:rollback)
+    end
+    assert_equal(0, fb.size)
+    assert_includes(log.to_s, 'rolled back', log)
+  end
+
   def test_with_modifying_txn
     log = Loog::Buffer.new
     fb = Factbase::Logged.new(Factbase.new, log)


### PR DESCRIPTION
`Factbase#txn` ends a transaction on `raise Factbase::Rollback` and on `throw :rollback`,
but `Logged#txn` only knew the first form, so a thrown rollback was logged as "touched
nothing". `Fbe.conclude` uses the throw, so the "rolled back" line never showed up in a
judge run.

`Logged#txn` now catches the throw the way `Tallied#txn` does, and re-throws it so the
transaction still rolls back.

Closes #772
