### PR TITLE
#764: print a string of bad bytes in Base64

### DIFF
--- a/lib/factbase/to_xml.rb
+++ b/lib/factbase/to_xml.rb
@@ -64,7 +64,7 @@ class Factbase::ToXML
   # @param [Symbol] name The name of the element
   # @param [Object] val The value
   def put(xml, name, val)
-    if val.is_a?(String) && val.match?(BAD)
+    if val.is_a?(String) && (!val.valid_encoding? || val.match?(BAD))
       xml.__send__(name, [val].pack('m0'), t: 'B')
     else
       xml.__send__(name, to_str(val), t: type_of(val))

--- a/test/factbase/test_to_xml.rb
+++ b/test/factbase/test_to_xml.rb
@@ -32,6 +32,16 @@ class TestToXML < Factbase::Test
     assert_equal("a#{1.chr}b", node.text.unpack1('m0'))
   end
 
+  def test_broken_utf8_rendering
+    fb = Factbase.new
+    bad = +"bad\xFF"
+    bad.force_encoding('UTF-8')
+    fb.insert.t = bad
+    node = Nokogiri::XML.parse(Factbase::ToXML.new(fb).xml, &:strict).xpath('/fb/f/t').first
+    assert_equal('B', node['t'])
+    assert_equal(bad.b, node.text.unpack1('m0').b)
+  end
+
   def test_complex_rendering
     fb = Factbase.new
     fb.insert.t = "\uffff < > & ' \""


### PR DESCRIPTION
The `BAD` match was the first thing done to a value, and matching a regular expression
against bytes that are not valid UTF-8 raises `ArgumentError` itself, so a string that
the Base64 branch exists for never reached it.

The encoding is now checked before the match, and such a string takes the same `t="B"`
path as a string with a character XML cannot hold.

Closes #764
