### PR TITLE
#765: name the property that JSON cannot hold

### DIFF
--- a/lib/factbase/to_json.rb
+++ b/lib/factbase/to_json.rb
@@ -30,16 +30,27 @@ class Factbase::ToJSON
   # @return [String] The factbase in JSON format
   def json
     Factbase::Flatten.new(@fb.each.to_a, @sorter).it.map do |m|
-      m.transform_values { |vv| vv.is_a?(Array) ? vv.map { |v| plain(v) } : plain(vv) }
+      m.to_h do |k, vv|
+        [k, vv.is_a?(Array) ? vv.map { |v| plain(m, k, v) } : plain(m, k, vv)]
+      end
     end.to_json
   end
 
   private
 
   # Render one value the way ToXML renders it.
+  # @param [Hash] map The fact the value belongs to
+  # @param [String] key The name of the property
   # @param [Object] val The value
   # @return [Object] The value, with a Time turned into ISO 8601
-  def plain(val)
+  def plain(map, key, val)
+    if val.is_a?(String) && !val.valid_encoding?
+      raise(
+        ArgumentError,
+        "The value #{val.inspect} of the '#{key}' property of the fact " \
+        "##{map['_id']} is not valid UTF-8 and JSON cannot hold it"
+      )
+    end
     val.is_a?(Time) ? val.utc.iso8601(6) : val
   end
 end

--- a/test/factbase/test_to_json.rb
+++ b/test/factbase/test_to_json.rb
@@ -55,6 +55,15 @@ class TestToJSON < Factbase::Test
     assert_equal('hello', JSON.parse(Factbase::ToJSON.new(fb).json)[0]['text'])
   end
 
+  def test_names_the_property_that_is_not_valid_utf8
+    fb = Factbase.new
+    bad = +"bad\xFF"
+    bad.force_encoding('UTF-8')
+    fb.insert.text = bad
+    e = assert_raises(StandardError) { Factbase::ToJSON.new(fb).json }
+    assert_includes(e.message, "'text'", e.message)
+  end
+
   def test_custom_sort_key
     fb = Factbase.new
     fb.insert.prio = 2


### PR DESCRIPTION
`Factbase::Fact` accepts a string whatever its encoding, so a value that is not valid
UTF-8 can sit in a factbase, and `ToJSON` then leaked `JSON::GeneratorError` with nothing
in it about where the bad value came from.

JSON has no place to mark an encoded value, the way XML has `t="B"`, so this takes the
other option the issue lists: the failure now names the property and the fact.

Closes #765
