### PR TITLE
#787: delete the facts the query yields, not the ones it evaluates

### DIFF
--- a/lib/factbase/query.rb
+++ b/lib/factbase/query.rb
@@ -88,8 +88,11 @@ class Factbase::Query
   # @return [Integer] Total number of facts deleted
   def delete!(fb = @fb)
     deleted = 0
+    maybe = (@term.predict(@maps, fb, Factbase::Tee.new({}, {})) || @maps).to_a.dup
     @maps.delete_if do |m|
-      d = @term.evaluate(Factbase::Accum.new(Factbase::Fact.new(m), {}, false), @maps, fb)
+      pos = maybe.index(m)
+      d = !pos.nil? && @term.evaluate(Factbase::Accum.new(Factbase::Fact.new(m), {}, false), @maps, fb)
+      maybe.delete_at(pos) if d
       deleted += 1 if d
       d
     end

--- a/test/factbase/test_query.rb
+++ b/test/factbase/test_query.rb
@@ -161,6 +161,12 @@ class TestQuery < Factbase::Test
     assert_equal(1, maps.size)
   end
 
+  def test_deletes_only_the_head
+    maps = [{ 'foo' => [0] }, { 'foo' => [1] }, { 'foo' => [2] }, { 'foo' => [3] }, { 'foo' => [4] }]
+    assert_equal(2, Factbase::Query.new(maps, '(head 2 (exists foo))', Factbase.new).delete!)
+    assert_equal([[2], [3], [4]], maps.map { |m| m['foo'] })
+  end
+
   def test_delete_by_id
     maps = [
       { '_id' => [1], 'fruit' => ['orange'] },


### PR DESCRIPTION
`delete!` had two paths. When every fact carries an id it collects the ids from `each`, which is
right. When one does not, it fell back to running the term against every fact, and `head`,
`sorted` and `inverted` all evaluate to `true` for everything: they narrow in `predict`, not in
`evaluate`. So `(head 2 ...)` deleted all five facts, and `(head 0 ...)` did too.

The fallback narrows through `predict` first now, the way `each` does, and takes each predicted
fact once, so two identical facts under `(head 1 ...)` lose one of them rather than both.

The predicted list is copied before it is walked: `predict` can hand back the very array that is
being deleted from, and consuming entries out of it while `delete_if` runs over it skipped facts.

Closes #787
