### PR TITLE
#788: refuse a float that is not a number

### DIFF
--- a/lib/factbase/fact.rb
+++ b/lib/factbase/fact.rb
@@ -59,6 +59,7 @@ class Factbase::Fact
         String, Integer, Float,
         Time, TrueClass, FalseClass
       ].include?(v.class)
+      raise(ArgumentError, "The value of '#{kk}' can't be #{v}") if v.is_a?(Float) && !v.finite?
       v = v.utc if v.is_a?(Time)
       @map[kk] = [] if @map[kk].nil?
       @map[kk] << v

--- a/test/factbase/test_fact.rb
+++ b/test/factbase/test_fact.rb
@@ -13,6 +13,13 @@ require_relative '../test__helper'
 # Copyright:: Copyright (c) 2024-2026 Yegor Bugayenko
 # License:: MIT
 class TestFact < Factbase::Test
+  def test_refuses_a_float_that_is_not_a_number
+    f = Factbase::Fact.new({})
+    [Float::NAN, Float::INFINITY, -Float::INFINITY].each do |v|
+      assert_raises(StandardError) { f.value = v }
+    end
+  end
+
   def test_injects_data_correctly
     map = {}
     f = Factbase::Fact.new(map)


### PR DESCRIPTION
A fact only checked the class of a value, so `Float::NAN` and `Float::INFINITY` went in, and
nothing afterwards could deal with them. `ToJSON` raised `NaN not allowed in JSON`, naming neither
the fact nor the property, so `judges print --format json` failed with the generator's own
message. `sorted` and every comparison under an index raised `comparison of Float with NaN
failed`, again naming nothing.

The value is refused at the door instead, next to the checks for nil and for an empty string, so
the message names the property the way those do.

Closes #788
