### PR TITLE
#785: give the facts back in the order they went in

### DIFF
--- a/lib/factbase/indexed/indexed_gt.rb
+++ b/lib/factbase/indexed/indexed_gt.rb
@@ -32,9 +32,9 @@ class Factbase::IndexedGt
 
   def _feed(facts, entry, prop)
     return unless entry[:count] < facts.size
-    facts[entry[:count]..].each do |fact|
+    facts[entry[:count]..].each_with_index do |fact, i|
       fact[prop]&.each do |v|
-        entry[:facts] << [v, fact]
+        entry[:facts] << [v, fact, entry[:count] + i]
       end
     end
     entry[:facts].sort_by! { |pair| pair[0] }
@@ -42,9 +42,9 @@ class Factbase::IndexedGt
   end
 
   def _search(entry, target)
-    idx = entry[:facts].bsearch_index { |v, _| v > target }
+    idx = entry[:facts].bsearch_index { |pair| pair[0] > target }
     return [] if idx.nil?
-    facts = entry[:facts][idx..].map { |_, f| f }
+    facts = entry[:facts][idx..].sort_by { |pair| pair[2] }.map { |pair| pair[1] }
     facts.uniq!(&:object_id)
     facts
   end

--- a/lib/factbase/indexed/indexed_lt.rb
+++ b/lib/factbase/indexed/indexed_lt.rb
@@ -32,9 +32,9 @@ class Factbase::IndexedLt
 
   def _feed(facts, entry, prop)
     return unless entry[:count] < facts.size
-    facts[entry[:count]..].each do |fact|
+    facts[entry[:count]..].each_with_index do |fact, i|
       fact[prop]&.each do |v|
-        entry[:facts] << [v, fact]
+        entry[:facts] << [v, fact, entry[:count] + i]
       end
     end
     entry[:facts].sort_by! { |pair| pair[0] }
@@ -42,9 +42,9 @@ class Factbase::IndexedLt
   end
 
   def _search(entry, target)
-    idx = entry[:facts].bsearch_index { |v, _| v >= target }
+    idx = entry[:facts].bsearch_index { |pair| pair[0] >= target }
     res = idx.nil? ? entry[:facts] : entry[:facts][0...idx]
-    facts = res.map { |_, f| f }
+    facts = res.sort_by { |pair| pair[2] }.map { |pair| pair[1] }
     facts.uniq!(&:object_id)
     facts
   end

--- a/test/factbase/indexed/test_indexed_gt.rb
+++ b/test/factbase/indexed/test_indexed_gt.rb
@@ -16,6 +16,20 @@ require_relative '../../test__helper'
 # Copyright:: Copyright (c) 2024-2026 Yegor Bugayenko
 # License:: MIT
 class TestIndexedGt < Factbase::Test
+  def test_keeps_the_order_the_facts_were_inserted_in
+    term = Factbase::Term.new(:gt, [:num, 1])
+    term.redress!(Factbase::IndexedTerm, idx: {})
+    maps = Factbase::Taped.new(
+      [
+        { 'num' => [5], 'tag' => ['t0'] },
+        { 'num' => [1], 'tag' => ['t1'] },
+        { 'num' => [3], 'tag' => ['t2'] },
+        { 'num' => [2], 'tag' => ['t3'] }
+      ]
+    )
+    assert_equal(%w[t0 t2 t3], term.predict(maps, Factbase.new, {}).to_a.map { |m| m['tag'].first })
+  end
+
   def test_predicts_on_gt
     term = Factbase::Term.new(:gt, [:foo, 42])
     term.redress!(Factbase::IndexedTerm, idx: {})

--- a/test/factbase/indexed/test_indexed_lt.rb
+++ b/test/factbase/indexed/test_indexed_lt.rb
@@ -16,6 +16,20 @@ require_relative '../../test__helper'
 # Copyright:: Copyright (c) 2024-2026 Yegor Bugayenko
 # License:: MIT
 class TestIndexedLt < Factbase::Test
+  def test_keeps_the_order_the_facts_were_inserted_in
+    term = Factbase::Term.new(:lt, [:num, 4])
+    term.redress!(Factbase::IndexedTerm, idx: {})
+    maps = Factbase::Taped.new(
+      [
+        { 'num' => [5], 'tag' => ['t0'] },
+        { 'num' => [1], 'tag' => ['t1'] },
+        { 'num' => [3], 'tag' => ['t2'] },
+        { 'num' => [2], 'tag' => ['t3'] }
+      ]
+    )
+    assert_equal(%w[t1 t2 t3], term.predict(maps, Factbase.new, {}).to_a.map { |m| m['tag'].first })
+  end
+
   def test_predicts_on_lt
     term = Factbase::Term.new(:lt, [:foo, 42])
     term.redress!(Factbase::IndexedTerm, idx: {})


### PR DESCRIPTION
The index keeps its pairs sorted by the compared value so that it can binary-search them, and it
handed the matches back in that order. A plain factbase yields in insertion order, so the same
query gave a different order depending on whether an index sat in front of it, and a judge that
takes the first match got a different fact in production than in a test.

Each pair carries the position of its fact now, and the matched slice is put back into that order
before the facts are handed out. The pairs stay sorted by value, so the search is the same.

Closes #785
