### PR TITLE
#786: name the term when an index cannot compare

### DIFF
--- a/lib/factbase/indexed/indexed_term.rb
+++ b/lib/factbase/indexed/indexed_term.rb
@@ -40,6 +40,10 @@ module Factbase::IndexedTerm
     return __send__(m, maps, fb, params) if respond_to?(m)
     _init_indexes unless @indexes
     @indexes[@op].predict(maps, fb, params) if @indexes.key?(@op)
+  rescue NoMethodError => e
+    raise(RuntimeError, "Probably the term '#{@op}' is not defined at #{self}: #{e.message}")
+  rescue StandardError => e
+    raise(RuntimeError, "#{e.message.inspect} at #{self} at #{e.backtrace[0]}")
   end
 
   private

--- a/test/factbase/indexed/test_indexed_term.rb
+++ b/test/factbase/indexed/test_indexed_term.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative '../../../lib/factbase'
+require_relative '../../../lib/factbase/indexed/indexed_factbase'
 require_relative '../../../lib/factbase/indexed/indexed_term'
 require_relative '../../../lib/factbase/taped'
 require_relative '../../../lib/factbase/term'
@@ -14,6 +15,14 @@ require_relative '../../test__helper'
 # Copyright:: Copyright (c) 2024-2026 Yegor Bugayenko
 # License:: MIT
 class TestIndexedTerm < Factbase::Test
+  def test_names_the_term_when_the_values_cannot_be_compared
+    fb = Factbase::IndexedFactbase.new(Factbase.new)
+    fb.insert.num = 5
+    fb.insert.num = 'alpha'
+    e = assert_raises(StandardError) { fb.query('(gt num 2)').each.to_a }
+    assert_includes(e.message, '(gt num 2)', e.message)
+  end
+
   def test_predicts_on_others
     term = Factbase::Term.new(:boom, [])
     term.redress!(Factbase::IndexedTerm, idx: {})


### PR DESCRIPTION
`Term#evaluate` wraps whatever goes wrong inside it with the term it happened in, which is why the
plain path says `"comparison of String with 2 failed" at (gt num 2)`. `predict` had no such
wrapper, and the indexed path raises there, when it sorts the pairs it wants to binary-search, so
the failure escaped as a bare `ArgumentError` naming neither the property nor the query.

`IndexedTerm#predict` wraps the same way `evaluate` does. The message still names the two stored
values rather than a value and the target, because that is what actually failed, but the term next
to it says which property and which query it came from.

Closes #786
