### PR TITLE
#800: Name the failed clause in a long conjunction rule

### DIFF
--- a/lib/factbase/rules.rb
+++ b/lib/factbase/rules.rb
@@ -128,11 +128,17 @@ class Factbase::Rules
     end
 
     def it(fact, fb)
-      return if Factbase::Syntax.new(@expr).to_term.evaluate(fact, [], fb)
-      raise(
-        ArgumentError,
-        "The fact doesn't match the #{(@expr.length > 32 ? "#{@expr[0..31]}..." : @expr).inspect} rule: #{fact}"
-      )
+      term = Factbase::Syntax.new(@expr).to_term
+      return if term.evaluate(fact, [], fb)
+      text = (@expr.length > 32 ? "#{@expr[0..31]}..." : @expr).inspect
+      failed = Check.failed(term, fact, fb)
+      text = "#{failed} of the #{text}" unless failed.nil? || failed.to_s == term.to_s
+      raise(ArgumentError, "The fact doesn't match the #{text} rule: #{fact}")
+    end
+
+    def self.failed(term, fact, fb)
+      return term unless term.op == :and
+      term.operands.find { |operand| !operand.evaluate(fact, [], fb) }
     end
   end
 

--- a/test/factbase/test_rules.rb
+++ b/test/factbase/test_rules.rb
@@ -169,4 +169,23 @@ class TestRules < Factbase::Test
       'Error message should truncate long expressions'
     )
   end
+
+  def test_error_message_names_failed_part_of_long_conjunction
+    f = Factbase::Rules.new(
+      Factbase.new,
+      <<~RULE
+        (and
+          # The rule is intentionally long enough that its beginning is not useful.
+          # This is how a rule read from a file normally begins.
+          (always)
+          (always)
+          (always)
+          (exists foo)
+        )
+      RULE
+    ).insert
+    message = assert_raises(StandardError) { f.bar = 42 }.message
+    assert_includes(message, '(exists foo)', 'Error message should name the failed term')
+    refute_includes(message, 'intentionally long enough', 'Error message should not name the header')
+  end
 end


### PR DESCRIPTION
Fixes #800.

`Factbase::Rules::Check` truncated every rule at 32 characters before putting
it in a violation. For a rule loaded from a file, those first characters are
the SPDX/license header, so the exception showed the header instead of the
failed rule. A long top-level conjunction also hid which clause was false.

The check now parses the expression once and, for a top-level `and`, reports
the first operand that evaluates to false. Short non-conjunction rules retain
their complete expression, while a long conjunction names the failing clause
rather than an arbitrary prefix.

The regression uses a long file-style header followed by `(exists foo)` and
asserts that the violation contains the failed clause but not the header.

Tests:

- `bundle exec rake test` — passed, 98.84% coverage;
- `bundle exec rubocop lib/factbase/rules.rb test/factbase/test_rules.rb` — passed.
