### PR TITLE
#799: Do not advertise implicit Ruby conversions on facts

### DIFF
--- a/lib/factbase/accum.rb
+++ b/lib/factbase/accum.rb
@@ -5,6 +5,7 @@
 
 require 'others'
 require_relative '../factbase'
+require_relative 'no_conversion'
 
 # Accumulator of props, a decorator of +Factbase::Fact+.
 #
@@ -59,4 +60,6 @@ class Factbase::Accum
       @props[k][0]
     end
   end
+
+  prepend Factbase::NoConversion
 end

--- a/lib/factbase/cached/cached_fact.rb
+++ b/lib/factbase/cached/cached_fact.rb
@@ -5,6 +5,7 @@
 
 require 'others'
 require_relative '../../factbase'
+require_relative '../no_conversion'
 
 # A single fact in a factbase, which is sensitive to changes.
 #
@@ -28,4 +29,6 @@ class Factbase::CachedFact
     @cache.clear if args[0].to_s.end_with?('=')
     @origin.__send__(*args)
   end
+
+  prepend Factbase::NoConversion
 end

--- a/lib/factbase/fact.rb
+++ b/lib/factbase/fact.rb
@@ -7,6 +7,7 @@ require 'json'
 require 'others'
 require 'time'
 require_relative '../factbase'
+require_relative 'no_conversion'
 
 # A single fact in a factbase.
 #
@@ -75,4 +76,6 @@ class Factbase::Fact
       v[0]
     end
   end
+
+  prepend Factbase::NoConversion
 end

--- a/lib/factbase/indexed/indexed_fact.rb
+++ b/lib/factbase/indexed/indexed_fact.rb
@@ -5,6 +5,7 @@
 
 require 'others'
 require_relative '../../factbase'
+require_relative '../no_conversion'
 
 # A single fact in a factbase, which is sensitive to changes.
 #
@@ -30,4 +31,6 @@ class Factbase::IndexedFact
     @idx.clear if args[0].to_s.end_with?('=') && !@fresh.include?(object_id)
     @origin.__send__(*args)
   end
+
+  prepend Factbase::NoConversion
 end

--- a/lib/factbase/inv.rb
+++ b/lib/factbase/inv.rb
@@ -6,6 +6,7 @@
 require 'decoor'
 require 'others'
 require_relative '../factbase'
+require_relative 'no_conversion'
 
 # A decorator of a Factbase, that checks invariants on every set.
 #
@@ -67,6 +68,8 @@ class Factbase::Inv
       @block.call(k[0..-2], args[1]) if k.end_with?('=')
       @fact.method_missing(*args)
     end
+
+    prepend Factbase::NoConversion
   end
 
   # Query decorator.

--- a/lib/factbase/logged.rb
+++ b/lib/factbase/logged.rb
@@ -7,6 +7,7 @@ require 'decoor'
 require 'others'
 require 'tago'
 require 'time'
+require_relative 'no_conversion'
 require_relative 'syntax'
 
 # A decorator of a Factbase, that logs all operations.
@@ -128,6 +129,8 @@ class Factbase::Logged
       end
       r
     end
+
+    prepend Factbase::NoConversion
   end
 
   # Query decorator.

--- a/lib/factbase/no_conversion.rb
+++ b/lib/factbase/no_conversion.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+# Prevents facts from claiming implicit Ruby conversions.
+module Factbase::NoConversion
+  PROTOCOLS = %i[to_ary to_str to_hash to_io to_proc to_int].freeze
+
+  def method_missing(method, ...)
+    raise(NoMethodError, "undefined method '#{method}' for #{self.class}") if PROTOCOLS.include?(method)
+    super
+  end
+
+  # rubocop:disable Elegant/GoodMethodName, Style/OptionalBooleanParameter
+  def respond_to?(method, include_private = false)
+    return false if PROTOCOLS.include?(method)
+    super
+  end
+  # rubocop:enable Elegant/GoodMethodName, Style/OptionalBooleanParameter
+
+  def respond_to_missing?(method, include_private = false)
+    return false if PROTOCOLS.include?(method)
+    super
+  end
+end

--- a/lib/factbase/rules.rb
+++ b/lib/factbase/rules.rb
@@ -7,6 +7,7 @@ require 'decoor'
 require 'others'
 require_relative '../factbase'
 require_relative '../factbase/accum'
+require_relative '../factbase/no_conversion'
 require_relative '../factbase/syntax'
 require_relative '../factbase/tallied'
 
@@ -93,6 +94,8 @@ class Factbase::Rules
       end
       @fact.method_missing(*args)
     end
+
+    prepend Factbase::NoConversion
   end
 
   # Query decorator.

--- a/lib/factbase/tallied.rb
+++ b/lib/factbase/tallied.rb
@@ -7,6 +7,7 @@ require 'decoor'
 require 'others'
 require_relative '../factbase'
 require_relative 'churn'
+require_relative 'no_conversion'
 
 # A decorator of a Factbase, that counts all operations and then returns
 # an instance of Factbase::Churn.
@@ -72,6 +73,8 @@ class Factbase::Tallied
       @churn.append(0, 0, 1) if args[0].to_s.end_with?('=')
       r
     end
+
+    prepend Factbase::NoConversion
   end
 
   # Query decorator.

--- a/lib/factbase/tee.rb
+++ b/lib/factbase/tee.rb
@@ -5,6 +5,7 @@
 
 require 'others'
 require_relative '../factbase'
+require_relative 'no_conversion'
 
 # Tee of two facts.
 #
@@ -42,4 +43,6 @@ class Factbase::Tee
       @fact.public_send(*args)
     end
   end
+
+  prepend Factbase::NoConversion
 end

--- a/test/factbase/test_no_conversion.rb
+++ b/test/factbase/test_no_conversion.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+require_relative '../../lib/factbase'
+require_relative '../../lib/factbase/accum'
+require_relative '../../lib/factbase/rules'
+require_relative '../../lib/factbase/tee'
+
+require_relative '../test__helper'
+
+# Test.
+class TestNoConversion < Factbase::Test
+  def test_does_not_claim_implicit_array_conversion
+    fact = self.fact
+    facts.each do |item|
+      refute_respond_to(item, :to_ary)
+      assert_equal([item], [item].flatten)
+    end
+    assert_equal([[fact, nil]], [fact].map { |one, two| [one, two] })
+  end
+
+  def test_converts_to_text_through_to_s
+    facts.each do |item|
+      refute_respond_to(item, :to_str)
+      assert_equal(item.to_s, [item].join)
+    end
+  end
+
+  private
+
+  def fact
+    f = Factbase.new.insert
+    f.foo = 1
+    f
+  end
+
+  def facts
+    fact = self.fact
+    [
+      fact,
+      Factbase::Accum.new(fact, {}, false),
+      Factbase::Tee.new(fact, {}),
+      Factbase::Rules::Fact.new(fact, nil, Factbase.new)
+    ]
+  end
+end


### PR DESCRIPTION
Fixes #799.

Facts use `others` for property access, whose fallback makes every missing
method look available. Ruby then treated a fact as if it implemented implicit
conversion protocols such as `to_ary` and `to_str`: `flatten` and block
destructuring tried to read those names as fact properties and raised instead
of preserving the object.

`Factbase::NoConversion` intercepts the protocol names before property lookup,
reports that they are not supported, and leaves ordinary dynamic properties
unchanged. It is prepended to the fact and every fact decorator so plain,
accumulated, tee, rules, logging, indexing, caching, and tallying paths agree.

The tests cover flattening, two-parameter block destructuring, and joining a
fact into text for the core fact forms. They fail on master with the dynamic
property error.

Tests:

- `bundle exec rake test` — passed, 98.85% coverage;
- `bundle exec rubocop` on all changed fact/decorator files — passed.
