### PR TITLE
#798: Pass outer query parameters to agg selectors

### DIFF
--- a/lib/factbase/terms/agg.rb
+++ b/lib/factbase/terms/agg.rb
@@ -29,6 +29,39 @@ class Factbase::Agg < Factbase::TermBase
     unless term.is_a?(Factbase::Term) || term.is_a?(Factbase::TermBase)
       raise(ArgumentError, "A term is expected, but '#{term}' provided")
     end
-    term.evaluate(nil, fb.query(selector, maps).each(fb, fact).to_a, fb)
+    term.evaluate(nil, fb.query(selector, maps).each(fb, params(fact)).to_a, fb)
+  end
+
+  private
+
+  # Extract the parameters made available to the outer query.
+  # @param [Factbase::Fact] fact The fact being evaluated
+  # @return [Hash] Parameters indexed by their names
+  def params(fact)
+    Context.new(fact, fact.all_properties.to_h { |name| [name, fact["$#{name}"]] }.compact)
+  end
+
+  # Values available to the selector of an aggregation.
+  class Context
+    # Ctor.
+    # @param [Factbase::Fact] fact The outer fact
+    # @param [Hash] params Parameters of the outer query
+    def initialize(fact, params)
+      @fact = fact
+      @params = params
+    end
+
+    # Get a parameter, or the property of the outer fact when it is not a parameter.
+    # @param [String] name Parameter or property name
+    # @return [Object] The value
+    def [](name)
+      @params.fetch(name) { @fact[name] }
+    end
+
+    # List all available names.
+    # @return [Array<String>] Names of the parameters and fact properties
+    def all_properties
+      @fact.all_properties | @params.keys
+    end
   end
 end

--- a/test/factbase/terms/test_agg.rb
+++ b/test/factbase/terms/test_agg.rb
@@ -71,4 +71,20 @@ class TestAgg < Factbase::Test
       )
     )
   end
+
+  def test_passes_outer_query_params_to_selector
+    fb = Factbase.new
+    [['eng', 100], ['eng', 200], ['ops', 50]].each do |dept, salary|
+      fact = fb.insert
+      fact.dept = dept
+      fact.salary = salary
+    end
+    %w[dept d x].each do |param|
+      assert_equal(
+        [200],
+        fb.query("(eq salary (agg (eq dept $#{param}) (max salary)))").each(fb, param => ['eng']).map(&:salary),
+        "parameter $#{param} wasn't passed to agg"
+      )
+    end
+  end
 end


### PR DESCRIPTION
Fixes #798.

`Agg#evaluate` passed the current fact as the second argument of `Query#each`.
That argument is the query-parameter map. Therefore `$dept` inside an `agg`
selector resolved against the current fact's `dept` property and ignored the
`dept: ['eng']` supplied by the caller. The README example could return the
`ops` fact or no facts depending only on the parameter's name.

The selector now receives a context that gives explicit outer-query
parameters precedence, while falling back to the current fact for the existing
correlated-query behavior when no parameter with that name exists. The
aggregation API and literal selectors remain unchanged.

The regression builds two engineering salaries and one operations salary, then
runs the README-shaped query with `$dept`, `$d`, and `$x`; all must select only
the 200 salary. Each name produced a different wrong result on master.

Tests:

- `bundle exec rake test` — passed, 98.84% coverage;
- `bundle exec rubocop lib/factbase/terms/agg.rb test/factbase/terms/test_agg.rb` — passed.
