### PR TITLE
#797: Explain unavailable operations in transaction blocks

### DIFF
--- a/lib/factbase/light.rb
+++ b/lib/factbase/light.rb
@@ -32,6 +32,20 @@ class Factbase::Light
   end
 
   def txn
-    raise(StandardError, 'You cannot start a transaction inside another transaction')
+    raise(StandardError, 'A transaction cannot be started inside a transaction')
+  end
+
+  def method_missing(method, ...)
+    if @fb.respond_to?(method)
+      raise(
+        StandardError,
+        "The '#{method}' operation is not available inside a transaction, use it on the factbase itself"
+      )
+    end
+    super
+  end
+
+  def respond_to_missing?(method, include_private = false)
+    @fb.respond_to?(method, include_private) || super
   end
 end

--- a/test/factbase/test_light.rb
+++ b/test/factbase/test_light.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+require_relative '../../lib/factbase'
+require_relative '../../lib/factbase/light'
+
+require_relative '../test__helper'
+
+# Test.
+class TestLight < Factbase::Test
+  def test_explains_unsupported_factbase_operations
+    fb = Factbase.new
+    fb.txn do |light|
+      assert_equal(
+        "The 'export' operation is not available inside a transaction, use it on the factbase itself",
+        assert_raises(StandardError) { light.export }.message
+      )
+    end
+  end
+
+  def test_keeps_unknown_operations_unknown
+    assert_match(
+      /undefined method 'unknown'/,
+      assert_raises(NoMethodError) { Factbase::Light.new(Factbase.new).unknown }.message
+    )
+  end
+
+  def test_explains_nested_transaction_without_assuming_its_caller
+    assert_equal(
+      'A transaction cannot be started inside a transaction',
+      assert_raises(StandardError) { Factbase::Light.new(Factbase.new).txn }.message
+    )
+  end
+end


### PR DESCRIPTION
Fixes #797.

`Factbase::Light` is the object exposed inside a transaction. It intentionally
does not offer operations such as `export` and `import`, but because those
methods were simply absent, callers got a bare `NoMethodError` naming an
internal class rather than the transaction restriction. Constructing `Light`
directly also produced a nested-transaction message that assumed its origin.

`Light#method_missing` now distinguishes a real operation of the wrapped
factbase from an unknown method. A supported-but-forbidden operation receives
a clear instruction to call it on the outer factbase; an unrelated name keeps
normal Ruby behavior. The nested transaction message describes the operation,
not an unverified caller history.

Tests cover a refused export, an unknown method, and a directly constructed
Light attempting to start a transaction.

Tests:

- `bundle exec rake test` — passed, 98.85% coverage;
- `bundle exec rubocop lib/factbase/light.rb test/factbase/test_light.rb` — passed.
