### PR TITLE
#796: Distinguish Boolean types in XML output

### DIFF
--- a/lib/factbase/to_xml.rb
+++ b/lib/factbase/to_xml.rb
@@ -25,6 +25,14 @@ require_relative '../factbase/flatten'
 # License:: MIT
 class Factbase::ToXML
   BAD = /[^\u0009\u000A\u000D\u0020-\uD7FF\uE000-\uFFFD\u{10000}-\u{10FFFF}]/
+  TYPES = {
+    'String' => 'S',
+    'Integer' => 'I',
+    'Float' => 'F',
+    'Time' => 'T',
+    'TrueClass' => 'L',
+    'FalseClass' => 'L'
+  }.freeze
 
   # Constructor.
   def initialize(fb, sorter = '_id')
@@ -80,6 +88,6 @@ class Factbase::ToXML
   end
 
   def type_of(val)
-    val.class.to_s[0]
+    TYPES.fetch(val.class.to_s) { raise(ArgumentError, "Can't put #{val.class} into XML") }
   end
 end

--- a/test/factbase/test_to_xml.rb
+++ b/test/factbase/test_to_xml.rb
@@ -94,6 +94,19 @@ class TestToXML < Factbase::Test
     ].each { |x| refute_empty(xml.xpath(x), out) }
   end
 
+  def test_marks_booleans_differently_from_floats_and_times
+    fb = Factbase.new
+    f = fb.insert
+    f.truth = true
+    f.lie = false
+    f.float = 2.5
+    f.time = Time.now
+    xml = Nokogiri::XML.parse(Factbase::ToXML.new(fb).xml)
+    %w[truth lie].each { |name| refute_empty(xml.xpath("/fb/f/#{name}[@t=\"L\"]")) }
+    refute_empty(xml.xpath('/fb/f/float[@t="F"]'))
+    refute_empty(xml.xpath('/fb/f/time[@t="T"]'))
+  end
+
   def test_sorts_keys
     fb = Factbase.new
     f = fb.insert


### PR DESCRIPTION
Fixes #796.

`ToXML` derived its one-letter type marker from the first character of the
Ruby class name. After Boolean values were accepted, `TrueClass` collided with
`Time` (`T`) and `FalseClass` with `Float` (`F`), so the attribute no longer
identified the value type.

The converter now uses an explicit mapping: String, Integer, Float, and Time
keep `S`, `I`, `F`, and `T`, while both Boolean classes use `L`. Unsupported
classes raise instead of silently introducing another accidental collision.

The regression serializes true, false, a Float, and a Time and checks each XML
attribute. Existing string, integer, float, time, and Base64-marker tests stay
unchanged.

Tests:

- `bundle exec rake test` — passed, 98.84% coverage;
- `bundle exec rubocop lib/factbase/to_xml.rb test/factbase/test_to_xml.rb` — passed.
