### PR TITLE
#795: Support Boolean literals in queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ There are a few terms that return non-boolean values:
 * `(at i v)` is the `i`-th value of `v`
 * `(size v)` is the cardinality of `v` (zero if `v` is `nil`)
 * `(type v)` is the type of `v`
-(`"String"`, `"Integer"`, `"Float"`, `"Time"`, or `"Array"`)
+(`"String"`, `"Integer"`, `"Float"`, `"Time"`, `"Boolean"`, or `"Array"`)
 * `(either v1 v2)` is `v2` if `v1` is `nil`
 
 It's possible to modify the facts retrieved, on fly:
@@ -259,8 +259,8 @@ There are some system-level terms:
 
 The entire database is a single flat [Ruby](https://www.ruby-lang.org/en/)
   `Array` of `Hash` objects held in RAM (`Factbase#@maps`). There are no
-  tables, schemas, or type enforcement beyond four scalar types: `Integer`,
-  `Float`, `String`, and `Time`. This contrasts with
+  tables, schemas, or type enforcement beyond six scalar types: `Integer`,
+  `Float`, `String`, `Time`, `TrueClass`, and `FalseClass`. This contrasts with
   [SQLite](https://sqlite.org/) (fixed-column tables on disk) and
   [MongoDB](https://www.mongodb.com/) (typed document collections). New
   programmers must understand that all data vanishes on process exit unless

--- a/lib/factbase.rb
+++ b/lib/factbase.rb
@@ -41,7 +41,7 @@ require 'yaml'
 #  }
 #
 # Value sets, as you can see, allow data of different types. However, there
-# are only four types are allowed: Integer, Float, String, and Time.
+# are six allowed types: Integer, Float, String, Time, TrueClass, and FalseClass.
 #
 # A factbase may be exported to a file and then imported back:
 #

--- a/lib/factbase/syntax.rb
+++ b/lib/factbase/syntax.rb
@@ -145,6 +145,10 @@ class Factbase::Syntax
         Float(t)
       elsif t.match?(/^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(\.[0-9]+)?Z$/)
         Time.parse(t)
+      elsif t == 'true'
+        true
+      elsif t == 'false'
+        false
       else
         raise(ArgumentError, "Wrong symbol format (#{t})") unless t.match?(/^\$?[_a-z][a-zA-Z0-9_]*$/)
         t.to_sym

--- a/lib/factbase/terms/type.rb
+++ b/lib/factbase/terms/type.rb
@@ -26,6 +26,7 @@ class Factbase::Type < Factbase::TermBase
     v = _by_symbol(0, fact)
     return 'nil' if v.nil?
     v = v[0] if v.respond_to?(:each) && v.size == 1
+    return 'Boolean' if v.is_a?(TrueClass) || v.is_a?(FalseClass)
     v.class.to_s
   end
 end

--- a/test/factbase/terms/test_type.rb
+++ b/test/factbase/terms/test_type.rb
@@ -20,5 +20,7 @@ class TestType < Factbase::Test
     assert_equal('String', t.evaluate(fact('foo' => 'bar'), [], Factbase.new))
     assert_equal('Float', t.evaluate(fact('foo' => 2.1), [], Factbase.new))
     assert_equal('Time', t.evaluate(fact('foo' => Time.now), [], Factbase.new))
+    assert_equal('Boolean', t.evaluate(fact('foo' => true), [], Factbase.new))
+    assert_equal('Boolean', t.evaluate(fact('foo' => false), [], Factbase.new))
   end
 end

--- a/test/factbase/test_syntax.rb
+++ b/test/factbase/test_syntax.rb
@@ -108,6 +108,11 @@ class TestSyntax < Factbase::Test
     end
   end
 
+  def test_parses_boolean_literals
+    assert(Factbase::Syntax.new('(eq flag true)').to_term.evaluate({ 'flag' => [true] }, [], Factbase.new))
+    assert(Factbase::Syntax.new('(eq flag false)').to_term.evaluate({ 'flag' => [false] }, [], Factbase.new))
+  end
+
   def test_parses_a_time_with_fractional_seconds
     t = Time.parse('2026-09-05T07:00:00.123456Z')
     assert(


### PR DESCRIPTION
Fixes #795.

Facts already accepted `true` and `false`, and `export`/`import` preserved
them. The query parser did not recognize the same values as literals: it read
`true` as the property name `:true`. Consequently `(exists enabled)` found a
stored Boolean but `(eq enabled true)` quietly matched nothing, making a
writable fact value impossible to query by value.

`true` and `false` are now parsed before generic symbols. `(type value)` also
returns the public vocabulary `Boolean` for both Ruby Boolean classes instead
of leaking `TrueClass` or `FalseClass`. The README and API documentation list
the now-supported scalar values and result names.

The regression tests evaluate `(eq flag true)` and `(eq flag false)` against
stored facts and assert `Boolean` for each value. Both fail on master.

Tests:

- `bundle exec rake test` — passed, 98.84% coverage;
- `bundle exec rubocop lib/factbase/syntax.rb lib/factbase/terms/type.rb lib/factbase.rb test/factbase/test_syntax.rb test/factbase/terms/test_type.rb` — passed.
