### PR TITLE
#794: Document zero-based nth positions

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,8 +231,9 @@ with the salary average in their departments
 There are also terms that match the entire factbase
 and must be used primarily inside the `(agg ..)` term:
 
-* `(nth v p)` returns the `p` property of the _v_-th fact (must be
-a positive integer)
+* `(nth v p)` returns the `p` property of the fact at position `v`, counting
+  from zero (must be a non-negative integer); `(nth 0 p)` is the same as
+  `(first p)`
 * `(first p)` returns the `p` property of the first fact
 * `(count)` returns the tally of facts
 * `(max p)` returns the maximum value of the `p` property in all facts


### PR DESCRIPTION
Fixes #794.

`nth` has always used an array position: it accepts zero, rejects only negative
values, and `(nth 0 p)` returns the same first value as `(first p)`. The README
said the opposite — "the v-th fact" with a positive integer — so a reader
naturally wrote `(nth 1 p)` for the first fact and silently received the
second one.

Changing the term to one-based indexing would alter every existing query. The
implementation and its validation message already agree with each other, so
this change moves the documentation to the stable, zero-based contract instead:
`v` is a non-negative position and `(nth 0 p)` is `(first p)`.

The aggregation tests already exercise `(nth 0 x)` and establish the existing
behavior. No runtime code is changed.

Tests:

- `bundle exec rake test` — passed, 98.84% coverage.
