### PR TITLE
#793: Check rules before writing fact properties

### DIFF
--- a/lib/factbase/rules.rb
+++ b/lib/factbase/rules.rb
@@ -6,6 +6,7 @@
 require 'decoor'
 require 'others'
 require_relative '../factbase'
+require_relative '../factbase/accum'
 require_relative '../factbase/syntax'
 require_relative '../factbase/tallied'
 
@@ -84,10 +85,13 @@ class Factbase::Rules
     end
 
     others do |*args|
-      r = @fact.method_missing(*args)
       k = args.first.to_s
-      @check.it(@fact, @fb) if k.end_with?('=')
-      r
+      if k.end_with?('=')
+        probe = Factbase::Accum.new(@fact, {}, false)
+        probe.method_missing(*args)
+        @check.it(probe, @fb)
+      end
+      @fact.method_missing(*args)
     end
   end
 

--- a/test/factbase/test_rules.rb
+++ b/test/factbase/test_rules.rb
@@ -152,6 +152,13 @@ class TestRules < Factbase::Test
     refute_includes(ex.message, 'nil', 'Error message should not contain "nil"')
   end
 
+  def test_does_not_write_a_value_rejected_by_a_rule
+    base = Factbase.new
+    fact = Factbase::Rules.new(base, '(exists foo)').insert
+    assert_raises(ArgumentError) { fact.bar = 42 }
+    assert_nil(base.query('(always)').each.to_a.first['bar'])
+  end
+
   def test_error_message_truncates_long_expression
     rule = '(and (exists a) (exists b) (exists c) (exists d) (exists e))'
     assert_operator(rule.length, :>, 32)


### PR DESCRIPTION
Fixes #793.

`Factbase::Rules::Fact` applied an assignment to its wrapped fact before it
checked the rule. Outside `txn`, there is no journal to undo that write. With
the rule `(exists foo)`, `fact.bar = 42` raised as intended but left
`bar: [42]` in the factbase — a caller rescuing the error was told that the
fact was rejected while the rejected value remained stored.

The order now matches `Factbase::Inv`: a temporary `Factbase::Accum` receives
the pending assignment with `pass: false`, the rule is evaluated against that
candidate, and only a successful candidate is forwarded to the actual fact.
Reads and assignments that satisfy the rule keep their previous path.

This deliberately does not change when a newly inserted, still-empty fact is
considered complete. There is no completion event outside a transaction, and
turning `insert` itself into a rule check would be a separate contract change.
The PR fixes the concrete broken atomicity of an assignment.

The regression test creates a Rules-wrapped factbase with `(exists foo)`,
attempts `bar = 42`, asserts the error, and then reads the wrapped factbase to
prove that `bar` was never written. It fails on master.

Tests:

- `bundle exec rake test` — passed, 98.84% coverage;
- `bundle exec rubocop lib/factbase/rules.rb test/factbase/test_rules.rb` — passed.
