### PR TITLE
#792: Name query terms in arity errors

### DIFF
--- a/lib/factbase/term.rb
+++ b/lib/factbase/term.rb
@@ -156,7 +156,7 @@ class Factbase::Term < Factbase::TermBase
     super()
     @op = operator
     @operands = operands
-    @terms = TERMS.transform_values { |c| c.new(operands) }
+    @terms = TERMS.to_h { |name, klass| [name, klass.new(operands).tap { |term| term.name = name }] }
   end
 
   # Extend it with the module.

--- a/lib/factbase/terms/base.rb
+++ b/lib/factbase/terms/base.rb
@@ -8,6 +8,18 @@
 # Copyright:: Copyright (c) 2024-2026 Yegor Bugayenko
 # License:: MIT
 class Factbase::TermBase
+  # Set the name the user used for this term and its implementation helpers.
+  # @param [Symbol] name Name of the term in the query
+  # rubocop:disable Elegant/GoodMethodName
+  def name=(name)
+    @name = name
+    instance_variables.each do |variable|
+      value = instance_variable_get(variable)
+      value.name = name if value.is_a?(Factbase::TermBase)
+    end
+  end
+  # rubocop:enable Elegant/GoodMethodName
+
   # Turns it into a string.
   # @return [String] The string of it
   def to_s
@@ -33,8 +45,9 @@ class Factbase::TermBase
 
   def assert_args(num)
     c = @operands.size
-    raise(ArgumentError, "Too many (#{c}) operands for '#{@op}' (#{num} expected)") if c > num
-    raise(ArgumentError, "Too few (#{c}) operands for '#{@op}' (#{num} expected)") if c < num
+    name = @name || @op
+    raise(ArgumentError, "Too many (#{c}) operands for '#{name}' (#{num} expected)") if c > num
+    raise(ArgumentError, "Too few (#{c}) operands for '#{name}' (#{num} expected)") if c < num
   end
 
   # Turns facts into plain maps, keeping only the properties they really carry.

--- a/test/factbase/test_syntax.rb
+++ b/test/factbase/test_syntax.rb
@@ -99,6 +99,15 @@ class TestSyntax < Factbase::Test
     assert(Factbase::Syntax.new('(eq t 1.5e-10)').to_term.evaluate({ 't' => 1.5e-10 }, [], Factbase.new))
   end
 
+  def test_names_the_term_with_too_few_operands
+    %w[size contains gte plus].each do |name|
+      fb = Factbase.new
+      fb.insert.foo = 42
+      error = assert_raises(RuntimeError) { fb.query("(#{name})").each.to_a }
+      assert_includes(error.message, "for '#{name}'", error.message)
+    end
+  end
+
   def test_parses_a_time_with_fractional_seconds
     t = Time.parse('2026-09-05T07:00:00.123456Z')
     assert(


### PR DESCRIPTION
Fixes #792.

`assert_args` reported the implementation's `@op`. That was not consistently
the query term: simple terms left it empty, comparison terms stored operators
such as `include?` or `>=`, and arithmetic terms stored `+`, `-`, `*`, or
`/`. Thus `(size)` became `Too few ... for ''`, while `(contains)` named a Ruby
method that a reader never wrote and cannot find in the README.

`Factbase::Term` is the single place that knows the operator parsed from the
query. It now gives that name to every dispatch target when it builds its term
table. A target may be a thin wrapper around another `TermBase` implementation
(for example, `contains` wraps a comparison), so the name travels to those
helpers as well. Arithmetic and comparison execution still use their existing
Ruby operators; only diagnostics have a separate, user-facing name.

The regression test evaluates zero-operand `size`, `contains`, `gte`, and
`plus` against a fact. They cover an unset `@op`, a Ruby method, a Ruby
operator, and an arithmetic wrapper. Each message now contains exactly the
term the query used; all four fail on master.

Tests:

- `bundle exec rake test` — passed, 98.84% coverage;
- `bundle exec rubocop lib/factbase/terms/base.rb lib/factbase/term.rb test/factbase/test_syntax.rb` — passed.
