### PR TITLE
#791: Explain invalid substring comparison operands

### DIFF
--- a/lib/factbase/terms/compare.rb
+++ b/lib/factbase/terms/compare.rb
@@ -44,7 +44,7 @@ class Factbase::Compare < Factbase::TermBase
   # @return [Boolean] The result of the comparison
   def _compare(left, right)
     left.__send__(@op, right)
-  rescue ArgumentError => e
+  rescue ArgumentError, NoMethodError => e
     raise(
       RuntimeError,
       "Cannot compare #{left.inspect} (#{left.class}) " \

--- a/test/factbase/terms/test_compare.rb
+++ b/test/factbase/terms/test_compare.rb
@@ -42,4 +42,12 @@ class TestCompare < Factbase::Test
     assert_includes(e.message, '"yesterday" (String)')
     assert_includes(e.message, 'comparison of Time with String failed')
   end
+
+  def test_wraps_a_missing_comparison_method
+    t = Factbase::Compare.new(:include?, [42, 7])
+    e = assert_raises(RuntimeError) { t.evaluate(fact, [], Factbase.new) }
+    assert_includes(e.message, 'Cannot compare 42 (Integer) with 7 (Integer)')
+    assert_includes(e.message, 'using (compare include?)')
+    assert_includes(e.message, "undefined method 'include?'")
+  end
 end


### PR DESCRIPTION
Fixes #791.

`Factbase::Term#evaluate` reserves its `NoMethodError` rescue for a term that
does not exist. `contains`, `starts_with`, and `ends_with` are implemented by
`Factbase::Compare`, however, and send `include?`, `start_with?`, or
`end_with?` to the left value. On an Integer that send raised `NoMethodError`,
which escaped to the outer rescue and became the false statement that the
documented query term was not defined.

`Compare` now handles that error alongside its existing `ArgumentError`
handling. The message keeps both values, their classes, the comparison
operation, and Ruby's original explanation. The outer term-level rescue is
unchanged, so an actually unknown query term still receives its existing
diagnostic.

The regression constructs `Compare` with `include?` and two Integers. It
asserts the message names the values and `(compare include?)`, as well as the
original missing-method explanation. It fails on master, where the inner
`NoMethodError` was allowed to be misclassified by `Term#evaluate`.

Tests:

- `bundle exec rake test` — passed, 98.84% coverage;
- `bundle exec rubocop lib/factbase/terms/compare.rb test/factbase/terms/test_compare.rb` — passed.
