### PR TITLE
#790: Aggregate multi-valued arithmetic operands

### DIFF
--- a/lib/factbase/terms/arithmetic.rb
+++ b/lib/factbase/terms/arithmetic.rb
@@ -25,12 +25,10 @@ class Factbase::Arithmetic < Factbase::TermBase
     assert_args(2)
     lefts = _values(0, fact, maps, fb)
     return if lefts.nil?
-    raise(ArgumentError, 'Too many values at first position, one expected') unless lefts.size == 1
     rights = _values(1, fact, maps, fb)
     return if rights.nil?
-    raise(ArgumentError, 'Too many values at second position, one expected') unless rights.size == 1
-    v = lefts[0]
-    r = rights[0]
+    v = aggregate(lefts)
+    r = aggregate(rights)
     if v.is_a?(Time) && r.is_a?(String)
       (num, units) = r.split
       begin
@@ -56,5 +54,15 @@ class Factbase::Arithmetic < Factbase::TermBase
     end
     raise(ArgumentError, 'Cannot divide by zero') if @op == :/ && r.is_a?(Numeric) && r.zero?
     v.__send__(@op, r)
+  end
+
+  private
+
+  # Aggregate every value supplied for one arithmetic operand.
+  # @param [Array] values Values of one operand
+  # @return [Object] Sum or product of the values
+  def aggregate(values)
+    return values[0] if values.size == 1
+    values.reduce(@op == :+ || @op == :- ? :+ : :*)
   end
 end

--- a/test/factbase/terms/test_math.rb
+++ b/test/factbase/terms/test_math.rb
@@ -102,6 +102,18 @@ class TestMath < Factbase::Test
     assert_nil(t.evaluate(fact, [], Factbase.new))
   end
 
+  def test_aggregates_multiple_values_before_arithmetic
+    values = fact('left' => [2, 3], 'right' => [7, 2])
+    {
+      plus: 14,
+      minus: -4,
+      times: 84,
+      div: 0
+    }.each do |operation, expected|
+      assert_equal(expected, Factbase::Term.new(operation, %i[left right]).evaluate(values, [], Factbase.new))
+    end
+  end
+
   def test_minus_time
     t = Factbase::Term.new(:minus, [:foo, '4 hours'])
     assert_equal(


### PR DESCRIPTION
Fixes #790.

The README defines `plus` and `minus` in terms of the sum of every value of
each operand, and `times` and `div` in terms of their products. Facts normally
store an array after repeated assignment, but `Arithmetic` rejected any array
larger than one before it performed an operation. Thus `x = 2; x = 3` made
`(plus x n)` fail rather than calculate `(2 + 3) + n`.

Each operand is now reduced before the binary operation: addition/subtraction
use a sum, multiplication/division a product. Single-valued operands retain
their exact existing value, which preserves the `Time` plus/minus duration
path and the existing zero-divisor check. The change does not invent an
aggregation for missing operands; they still return `nil`.

The regression test uses two multi-valued numeric properties, `[2, 3]` and
`[7, 2]`, and exercises all four operations. It expects 14, -4, 84, and 0
under Ruby integer division. Before this PR each case raised the old
"Too many values" error.

Tests:

- `bundle exec rake test` — passed, 98.84% coverage;
- `bundle exec rubocop lib/factbase/terms/arithmetic.rb test/factbase/terms/test_math.rb` — passed.
