### PR TITLE
#784: Skip One indexing for subterm operands

### DIFF
--- a/lib/factbase/indexed/indexed_one.rb
+++ b/lib/factbase/indexed/indexed_one.rb
@@ -11,7 +11,9 @@ class Factbase::IndexedOne
   end
 
   def predict(maps, _fb, _params)
-    prop = @term.operands.first.to_s
+    operand = @term.operands.first
+    return unless operand.is_a?(Symbol)
+    prop = operand.to_s
     key = [maps.object_id, prop, @term.op]
     @idx[key] ||= { facts: [], count: 0 }
     entry = @idx[key]

--- a/test/factbase/indexed/test_indexed_one.rb
+++ b/test/factbase/indexed/test_indexed_one.rb
@@ -40,6 +40,12 @@ class TestIndexedOne < Factbase::Test
     end
   end
 
+  def test_skips_a_subterm_operand
+    term = Factbase::Term.new(:one, [Factbase::Term.new(:eq, [:kind, 'a'])])
+    term.redress!(Factbase::IndexedTerm, idx: {})
+    assert_nil(term.predict([{ 'kind' => ['a'] }], nil, {}))
+  end
+
   private
 
   def _assert_one


### PR DESCRIPTION
Fixes #784.

`IndexedOne` assumed that the operand of `(one ...)` was always a property
name. For `(one (eq kind "a"))`, it converted the nested term to the literal
property name `(eq kind "a")`, found that no fact had such a property, and
returned an empty candidate list. The unindexed `One` evaluates subterms as a
single value, so the two factbase implementations gave different answers.

The index now explicitly accepts only a Symbol operand. This retains the fast
property-name index for `(one kind)` and declines optimization for a nested
term. `IndexedTerm` treats `nil` as "no safe prediction", so the standard
term evaluator handles the subterm and preserves plain Factbase semantics.

The regression redresses `(one (eq kind "a"))` with `IndexedTerm` and asserts
that prediction is declined. It fails on master, where the index returned an
empty array. Existing tests still cover Array, Taped, and LazyTaped property
maps, ensuring the optimized path remains intact.

Tests:

- `bundle exec rake test` — passed, 98.84% coverage;
- `bundle exec rubocop lib/factbase/indexed/indexed_one.rb test/factbase/indexed/test_indexed_one.rb` — passed.
