### PR TITLE
#783: Preserve range errors with mixed indexed values

### DIFF
--- a/lib/factbase/indexed/indexed_gt.rb
+++ b/lib/factbase/indexed/indexed_gt.rb
@@ -16,6 +16,7 @@ class Factbase::IndexedGt
     prop = op1.to_s
     target = op2.is_a?(Symbol) ? params[op2.to_s]&.first : op2
     return maps || [] if target.nil?
+    return unless sortable?(maps, prop)
     key = [maps.object_id, prop, :facts]
     @idx[key] ||= { facts: [], count: 0 }
     entry = @idx[key]
@@ -39,6 +40,13 @@ class Factbase::IndexedGt
     end
     entry[:facts].sort_by! { |pair| pair[0] }
     entry[:count] = facts.size
+  end
+
+  def sortable?(maps, prop)
+    maps.to_a.flat_map { |fact| fact[prop] || [] }.sort
+    true
+  rescue ArgumentError
+    false
   end
 
   def _search(entry, target)

--- a/lib/factbase/indexed/indexed_gte.rb
+++ b/lib/factbase/indexed/indexed_gte.rb
@@ -16,6 +16,7 @@ class Factbase::IndexedGte
     prop = op1.to_s
     target = op2.is_a?(Symbol) ? params[op2.to_s]&.first : op2
     return maps || [] if target.nil?
+    return unless sortable?(maps, prop)
     key = [maps.object_id, prop, :facts]
     @idx[key] ||= { facts: [], count: 0 }
     entry = @idx[key]
@@ -39,6 +40,13 @@ class Factbase::IndexedGte
     end
     entry[:facts].sort_by! { |pair| pair[0] }
     entry[:count] = facts.size
+  end
+
+  def sortable?(maps, prop)
+    maps.to_a.flat_map { |fact| fact[prop] || [] }.sort
+    true
+  rescue ArgumentError
+    false
   end
 
   def _search(entry, target)

--- a/lib/factbase/indexed/indexed_lt.rb
+++ b/lib/factbase/indexed/indexed_lt.rb
@@ -16,6 +16,7 @@ class Factbase::IndexedLt
     prop = op1.to_s
     target = op2.is_a?(Symbol) ? params[op2.to_s]&.first : op2
     return maps || [] if target.nil?
+    return unless sortable?(maps, prop)
     key = [maps.object_id, prop, :facts]
     @idx[key] ||= { facts: [], count: 0 }
     entry = @idx[key]
@@ -39,6 +40,13 @@ class Factbase::IndexedLt
     end
     entry[:facts].sort_by! { |pair| pair[0] }
     entry[:count] = facts.size
+  end
+
+  def sortable?(maps, prop)
+    maps.to_a.flat_map { |fact| fact[prop] || [] }.sort
+    true
+  rescue ArgumentError
+    false
   end
 
   def _search(entry, target)

--- a/lib/factbase/indexed/indexed_lte.rb
+++ b/lib/factbase/indexed/indexed_lte.rb
@@ -16,6 +16,7 @@ class Factbase::IndexedLte
     prop = op1.to_s
     target = op2.is_a?(Symbol) ? params[op2.to_s]&.first : op2
     return maps || [] if target.nil?
+    return unless sortable?(maps, prop)
     key = [maps.object_id, prop, :facts]
     @idx[key] ||= { facts: [], count: 0 }
     entry = @idx[key]
@@ -39,6 +40,13 @@ class Factbase::IndexedLte
     end
     entry[:facts].sort_by! { |pair| pair[0] }
     entry[:count] = facts.size
+  end
+
+  def sortable?(maps, prop)
+    maps.to_a.flat_map { |fact| fact[prop] || [] }.sort
+    true
+  rescue ArgumentError
+    false
   end
 
   def _search(entry, target)

--- a/test/factbase/indexed/test_indexed_query.rb
+++ b/test/factbase/indexed/test_indexed_query.rb
@@ -46,6 +46,19 @@ class TestIndexedQuery < Factbase::Test
     end
   end
 
+  def test_range_queries_with_mixed_types_match_plain_factbase_errors
+    maps = [{ 'n' => [5] }, { 'n' => ['oops'] }]
+    %w[gt gte lt lte].each do |operation|
+      plain = Factbase.new(Marshal.load(Marshal.dump(maps)))
+      indexed = Factbase::IndexedFactbase.new(Factbase.new(Marshal.load(Marshal.dump(maps))))
+      query = "(#{operation} n 0)"
+      assert_equal(
+        assert_raises(RuntimeError) { plain.query(query).each.to_a }.message,
+        assert_raises(RuntimeError) { indexed.query(query).each.to_a }.message
+      )
+    end
+  end
+
   def test_fills_up_the_index
     idx = {}
     fb = Factbase::IndexedFactbase.new(Factbase.new, idx)


### PR DESCRIPTION
Fixes #783.

The range indexes sort raw property values before they select candidates. When
a property held both an Integer and a String, that internal sort raised a bare
`ArgumentError`. Plain Factbase does not sort first: `Compare` evaluates the
requested operator and raises a contextual `RuntimeError` that identifies the
two values and their types. Adding `IndexedFactbase` therefore changed both
the error class and the explanation of the same query.

Each indexed range term now checks whether the candidate property values can
be sorted before it creates or extends its cache. If they cannot, prediction
returns `nil` and the ordinary comparison path runs. No partial index entry is
stored, so later queries do not inherit a failed sort. Homogeneous properties
retain the existing index and binary-search path.

The regression runs `gt`, `gte`, `lt`, and `lte` against the same mixed
Integer/String facts through plain and IndexedFactbase. For every operation it
asserts both raise `RuntimeError` with identical messages. The indexed path
raised a bare `ArgumentError` on master.

Tests:

- `bundle exec rake test` — passed, 98.86% coverage;
- `bundle exec rubocop lib/factbase/indexed/indexed_gt.rb lib/factbase/indexed/indexed_gte.rb lib/factbase/indexed/indexed_lt.rb lib/factbase/indexed/indexed_lte.rb test/factbase/indexed/test_indexed_query.rb` — passed.
