### PR TITLE
#806: wrap every fact the cached query yields

### DIFF
--- a/lib/factbase/cached/cached_factbase.rb
+++ b/lib/factbase/cached/cached_factbase.rb
@@ -49,9 +49,7 @@ class Factbase::CachedFactbase
   # @param [Array<Hash>] maps Possible maps to use
   def query(term, maps = nil)
     term = to_term(term) if term.is_a?(String)
-    q = @origin.query(term, maps)
-    q = Factbase::CachedQuery.new(q, @cache, self) unless term.abstract?
-    q
+    Factbase::CachedQuery.new(@origin.query(term, maps), @cache, self, cacheable: !term.abstract?)
   end
 
   # Run an ACID transaction.

--- a/lib/factbase/cached/cached_query.rb
+++ b/lib/factbase/cached/cached_query.rb
@@ -17,10 +17,13 @@ class Factbase::CachedQuery
   # Constructor.
   # @param [Factbase::Query] origin Original query
   # @param [Hash] cache The cache
-  def initialize(origin, cache, fb)
+  # @param [Factbase] fb The factbase
+  # @param [Boolean] cacheable Whether the result of the query may be cached
+  def initialize(origin, cache, fb, cacheable: true)
     @origin = origin
     @cache = cache
     @fb = fb
+    @cacheable = cacheable
   end
 
   # Print it as a string.
@@ -36,10 +39,8 @@ class Factbase::CachedQuery
   def each(fb = @fb, params = {})
     return to_enum(__method__, fb, params) unless block_given?
     invalidate_if_dirty!
-    key = "each #{@origin}"
-    @cache[key] = @origin.each(fb, params).to_a if @cache[key].nil?
     c = 0
-    @cache[key].each do |f|
+    facts(fb, params).each do |f|
       c += 1
       yield(Factbase::CachedFact.new(f, @cache))
     end
@@ -52,6 +53,7 @@ class Factbase::CachedQuery
   # @return The value evaluated
   def one(fb = @fb, params = {})
     invalidate_if_dirty!
+    return @origin.one(fb, params) unless @cacheable
     key = "one: #{@origin} #{params}"
     @cache[key] = @origin.one(fb, params) if @cache[key].nil?
     @cache[key]
@@ -65,6 +67,17 @@ class Factbase::CachedQuery
   end
 
   private
+
+  # The facts the query yields, from the cache when the term allows it.
+  # @param [Factbase] fb The factbase
+  # @param [Hash] params Optional params accessible in the query via the "$" symbol
+  # @return [Array<Factbase::Fact>] The facts
+  def facts(fb, params)
+    return @origin.each(fb, params).to_a unless @cacheable
+    key = "each #{@origin}"
+    @cache[key] = @origin.each(fb, params).to_a if @cache[key].nil?
+    @cache[key]
+  end
 
   # Clear cache if it was marked dirty by a fresh fact insertion.
   # This implements lazy invalidation: we don't clear on every insert,

--- a/test/factbase/cached/test_cached_factbase.rb
+++ b/test/factbase/cached/test_cached_factbase.rb
@@ -20,6 +20,14 @@ class TestCachedFactbase < Factbase::Test
     assert_equal(1, fb.query('(and (eq foo_bar 1) (eq bar "test"))').each.to_a.size)
   end
 
+  def test_queries_after_update_through_a_parameterized_query
+    fb = Factbase::CachedFactbase.new(Factbase.new)
+    fb.insert.then { |f| f.foo = 1 }
+    assert_equal(0, fb.query('(gt foo 5)').each.to_a.size)
+    fb.query('(eq foo $x)').each(fb, x: [1]) { |f| f.foo = 9 }
+    assert_equal(1, fb.query('(gt foo 5)').each.to_a.size)
+  end
+
   def test_queries_after_update_in_txn
     origin = Factbase.new
     fb = Factbase::CachedFactbase.new(origin)


### PR DESCRIPTION
A term holding a `$` is abstract, so the query came back unwrapped, and the facts it yielded were plain ones rather than `Factbase::CachedFact`. Only `CachedFact` clears the cache when a property is written, so a write through such a query left every earlier answer in place.

Every query is wrapped now, and the term decides only whether the result may be cached, which is the shape the indexed decorator already uses.

Closes #806
