### PR TITLE
#823: keep the sprintf context when an operand is nil

### DIFF
--- a/lib/factbase/terms/sprintf.rb
+++ b/lib/factbase/terms/sprintf.rb
@@ -33,7 +33,7 @@ class Factbase::Sprintf < Factbase::TermBase
 
   def formatted(fmt, ops)
     format(*([fmt] + ops))
-  rescue ArgumentError => e
+  rescue ArgumentError, TypeError => e
     raise(RuntimeError, "Cannot format #{ops.inspect} with '#{fmt}' in (sprintf ...): #{e.message}")
   end
 end

--- a/test/factbase/terms/test_sprintf.rb
+++ b/test/factbase/terms/test_sprintf.rb
@@ -31,6 +31,18 @@ class TestSprintf < Factbase::Test
     assert_includes(e.message, 'invalid value for Integer')
   end
 
+  def test_names_the_format_when_an_operand_is_absent
+    [['%d', :absent], ['%f', :absent]].each do |ops|
+      t = Factbase::Sprintf.new(ops)
+      e =
+        assert_raises(RuntimeError) do
+          t.evaluate(fact, [], Factbase.new)
+        end
+      assert_includes(e.message, "Cannot format [nil] with '#{ops[0]}' in (sprintf ...):")
+      assert_includes(e.message, 'nil')
+    end
+  end
+
   def test_rejects_missing_format_operand
     t = Factbase::Sprintf.new(['%s %s', 'hello'])
     e =


### PR DESCRIPTION
Fixes #823

`formatted` rescued only `ArgumentError`, but `Kernel#format` answers `nil` with a `TypeError`, and an operand is `nil` exactly when the fact does not carry that property, which is the common case. The `TypeError` went past the rescue and reached the caller as bare `can't convert nil into Integer`, naming neither the format nor the operands, while every other failure in the same method arrives as `Cannot format [...] with '...' in (sprintf ...)`.

Rescuing `TypeError` alongside `ArgumentError` puts the missing-property case in the same shape as the rest. Nothing else changes: the class raised is still `RuntimeError`, and the three existing cases keep their messages.

The new test covers `%d` and `%f` with an absent property. It fails on master, where the raised class is `TypeError`.
