### PR TITLE
#807: put a modified fact back where it was

### DIFF
--- a/lib/factbase.rb
+++ b/lib/factbase.rb
@@ -199,13 +199,25 @@ class Factbase
       @maps << b
       churn.append(1, 0, 0)
     end
+    positions = nil
     taped.added.each do |oid|
       b = taped.find_by_object_id(oid)
       next if b.nil?
       next if seen.key?(b)
       original = taped.source_of(b)
-      garbage[original] = true if original
-      @maps << b
+      positions ||=
+        begin
+          h = {}.compare_by_identity
+          @maps.each_with_index { |m, i| h[m] = i }
+          h
+        end
+      pos = original.nil? || garbage.key?(original) ? nil : positions[original]
+      if pos.nil?
+        garbage[original] = true if original
+        @maps << b
+      else
+        @maps[pos] = b
+      end
       churn.append(0, 0, 1)
     end
     @maps.delete_if { |m| garbage.key?(m) } unless garbage.empty?

--- a/test/test_factbase.rb
+++ b/test/test_factbase.rb
@@ -270,6 +270,14 @@ class TestFactbase < Factbase::Test
     assert_equal(1, fb.query('(eq foo 1)').each.to_a.size)
   end
 
+  def test_keeps_order_when_modifying_a_fact_in_txn
+    fb = Factbase.new
+    3.times { |i| fb.insert.then { |f| f.num = i } }
+    fb.txn { |fbt| fbt.query('(eq num 0)').each { |f| f.tag = 'x' } }
+    assert_equal([0, 1, 2], fb.query('(always)').each.to_a.map(&:num))
+    assert_equal(1, fb.query('(exists tag)').each.to_a.size)
+  end
+
   def test_simple_concurrent_inserts
     fb = Factbase.new
     t = Concurrent.processor_count * 20


### PR DESCRIPTION
Closes #807.

A transaction that only read a fact and added a property to it moved that fact to the end of the factbase, while the same edit outside a transaction left the order alone:

```ruby
fb = Factbase.new
3.times { |i| fb.insert.then { |f| f.num = i } }
fb.txn { |t| t.query('(eq num 0)').each { |f| f.tag = 'x' } }
fb.query('(always)').each.to_a.map(&:num)  # => [1, 2, 0], expected [0, 1, 2]
```

`txn` committed a modification by appending the copy and marking the original as garbage, so the fact was effectively deleted and re-inserted. Insertion order is the only ordering this gem guarantees, and `Factbase#each`, `Query#each`, `(first p)`, `(nth v p)` and `(inverted p)` all read it, so a judge that annotates facts inside a transaction — the ordinary way judges are written — reordered the factbase as a side effect of reading it.

The copy now takes the place of the original instead.

Two cases keep the old behaviour deliberately:

- a copy whose original is no longer in the maps is appended, as before;
- a copy whose original is being deleted in the same transaction is appended too, so a fact that was modified and then deleted still survives exactly as it did before this change.

Positions are collected once, and only when `taped.added` actually has something to place, so this stays linear instead of scanning the maps for every modified fact. The `inserted` loop only appends, so indexes taken after it stay valid, and replacing in place never shifts them.

Verified on a fork before opening this: `bundle exec rake` is green on ubuntu-24.04, macos-15 and windows-2022 with Ruby 3.4 — 630 tests, 33344 assertions, 0 failures, 0 errors.