### PR TITLE
Make backslash escaping reversible in queries

### DIFF
--- a/lib/factbase/syntax.rb
+++ b/lib/factbase/syntax.rb
@@ -101,19 +101,30 @@ class Factbase::Syntax
     quotes = ['\'', '"']
     spaces = [' ', ')', "\n", "\t", "\r"]
     string = false
+    escaped = false
     comment = false
     @query.to_s.chars.each do |c|
       comment = true if !string && c == '#'
       comment = false if comment && c == "\n"
       next if comment
-      if quotes.include?(c)
-        if string && acc[-1] == '\\'
-          acc = acc[0..-2]
-        else
-          string = !string
-        end
-      end
       if string
+        if escaped
+          acc = acc[0..-2] if c == '\\' || quotes.include?(c)
+          acc += c
+          escaped = false
+        elsif c == '\\'
+          acc += c
+          escaped = true
+        elsif quotes.include?(c)
+          string = false
+          acc += c
+        else
+          acc += c
+        end
+        next
+      end
+      if quotes.include?(c)
+        string = true
         acc += c
         next
       end

--- a/lib/factbase/terms/base.rb
+++ b/lib/factbase/terms/base.rb
@@ -18,7 +18,7 @@ class Factbase::TermBase
         items +=
           @operands.map do |o|
             if o.is_a?(String)
-              "'#{o.gsub("'", "\\\\'").gsub('"', '\\\\"')}'"
+              "'#{o.gsub('\\') { '\\\\' }.gsub("'", "\\\\'").gsub('"', '\\\\"')}'"
             elsif o.is_a?(Time)
               o.utc.iso8601
             else

--- a/test/factbase/test_syntax.rb
+++ b/test/factbase/test_syntax.rb
@@ -27,11 +27,10 @@ class TestSyntax < Factbase::Test
   end
 
   def test_queries_values_with_backslashes
-    ["a\\b", "a\\\\b", "a\\", "a\\'b", "a\\\"b"].each do |value|
+    ['a\\b', 'a\\\\b', 'a\\', "a\\'b", 'a\"b'].each do |value|
       fb = Factbase.new
       fb.insert.foo = value
-      escaped = value.gsub('\\') { '\\\\' }.gsub("'", "\\\\'").gsub('"', '\\\\"')
-      query = "(eq foo '#{escaped}')"
+      query = "(eq foo '#{value.gsub('\\') { '\\\\' }.gsub("'", "\\\\'").gsub('"', '\\\\"')}')"
       assert_equal(query, Factbase::Term.new(:eq, [:foo, value]).to_s, query)
       assert_equal(1, fb.query(query).each.to_a.size, query)
       assert_equal(query, Factbase::Syntax.new(query).to_term.to_s, query)

--- a/test/factbase/test_syntax.rb
+++ b/test/factbase/test_syntax.rb
@@ -26,6 +26,18 @@ class TestSyntax < Factbase::Test
     assert_equal("(eq foo '')", Factbase::Syntax.new('(eq foo "")').to_term.to_s)
   end
 
+  def test_queries_values_with_backslashes
+    ["a\\b", "a\\\\b", "a\\", "a\\'b", "a\\\"b"].each do |value|
+      fb = Factbase.new
+      fb.insert.foo = value
+      escaped = value.gsub('\\') { '\\\\' }.gsub("'", "\\\\'").gsub('"', '\\\\"')
+      query = "(eq foo '#{escaped}')"
+      assert_equal(query, Factbase::Term.new(:eq, [:foo, value]).to_s, query)
+      assert_equal(1, fb.query(query).each.to_a.size, query)
+      assert_equal(query, Factbase::Syntax.new(query).to_term.to_s, query)
+    end
+  end
+
   def test_matches_empty_string_literal
     fb = Factbase.new
     fb.insert.foo = 'hello'


### PR DESCRIPTION
## What changed

Teach the query tokenizer to treat backslashes as escapes for both quotes and backslashes, and escape backslashes when serializing string operands. This makes values with a trailing backslash or a backslash before a quote representable and round-trip safely.

The syntax tests now cover one and two backslashes, a trailing backslash, and backslash/quote combinations, including querying the stored values.

Closes #821.
