### PR TITLE
#833: let a rollback thrown inside a tallied transaction reach the core

### DIFF
--- a/lib/factbase/tallied.rb
+++ b/lib/factbase/tallied.rb
@@ -42,7 +42,7 @@ class Factbase::Tallied
         yield(Factbase::Tallied.new(fbt, @churn))
         commit = true
       end
-      throw :rollback unless commit
+      throw(:rollback) unless commit
     rescue Factbase::Rollback => e
       @churn = before
       raise(e)

--- a/lib/factbase/tallied.rb
+++ b/lib/factbase/tallied.rb
@@ -42,6 +42,7 @@ class Factbase::Tallied
         yield(Factbase::Tallied.new(fbt, @churn))
         commit = true
       end
+      throw :rollback unless commit
     rescue Factbase::Rollback => e
       @churn = before
       raise(e)

--- a/test/factbase/test_tallied_rollback.rb
+++ b/test/factbase/test_tallied_rollback.rb
@@ -3,9 +3,9 @@
 # SPDX-FileCopyrightText: Copyright (c) 2024-2026 Yegor Bugayenko
 # SPDX-License-Identifier: MIT
 
-require_relative '../test__helper'
 require_relative '../../lib/factbase'
 require_relative '../../lib/factbase/tallied'
+require_relative '../test__helper'
 
 # Test.
 # Author:: Yegor Bugayenko (yegor256@gmail.com)

--- a/test/factbase/test_tallied_rollback.rb
+++ b/test/factbase/test_tallied_rollback.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+require_relative '../test__helper'
+require_relative '../../lib/factbase'
+require_relative '../../lib/factbase/tallied'
+
+# Test.
+# Author:: Yegor Bugayenko (yegor256@gmail.com)
+# Copyright:: Copyright (c) 2024-2026 Yegor Bugayenko
+# License:: MIT
+class TestTalliedRollback < Factbase::Test
+  def test_forgets_facts_inserted_before_rollback
+    fb = Factbase::Tallied.new(Factbase.new)
+    fb.insert.foo = 1
+    fb.txn do |t|
+      t.insert.bar = 2
+      throw :rollback
+    end
+    assert_equal(1, fb.size)
+  end
+end

--- a/test/factbase/test_tallied_rollback.rb
+++ b/test/factbase/test_tallied_rollback.rb
@@ -17,7 +17,7 @@ class TestTalliedRollback < Factbase::Test
     fb.insert.foo = 1
     fb.txn do |t|
       t.insert.bar = 2
-      throw :rollback
+      throw(:rollback)
     end
     assert_equal(1, fb.size)
   end


### PR DESCRIPTION
`Tallied#txn` caught `:rollback` itself and never passed it on, so the core
transaction committed the facts and only the churn counter was rolled back.
It now re-throws, the way `Logged` does.

Closes #833
