### PR TITLE
#831: refuse a negative position in the `at` term

### DIFF
--- a/lib/factbase/term.rb
+++ b/lib/factbase/term.rb
@@ -260,6 +260,7 @@ class Factbase::Term < Factbase::TermBase
     raise(RuntimeError, "Too many values (#{i.size}) at first position, one expected") unless i.size == 1
     i = i[0]
     return if i.nil?
+    raise(ArgumentError, "A non-negative position is expected, but #{i} provided") if i.negative?
     v = _values(1, fact, maps, fb)
     return if v.nil?
     v[i]

--- a/test/factbase/test_term_at.rb
+++ b/test/factbase/test_term_at.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+require_relative '../test__helper'
+require_relative '../../lib/factbase'
+
+# Test.
+# Author:: Yegor Bugayenko (yegor256@gmail.com)
+# Copyright:: Copyright (c) 2024-2026 Yegor Bugayenko
+# License:: MIT
+class TestTermAt < Factbase::Test
+  def test_refuses_a_negative_position
+    fb = Factbase.new
+    f = fb.insert
+    f.foo = 1
+    f.foo = 2
+    e =
+      assert_raises(StandardError) do
+        fb.query('(eq 2 (at -1 foo))').each.to_a
+      end
+    assert_includes(e.message, 'A non-negative position is expected, but -1 provided', e.message)
+  end
+end

--- a/test/factbase/test_term_at.rb
+++ b/test/factbase/test_term_at.rb
@@ -3,8 +3,8 @@
 # SPDX-FileCopyrightText: Copyright (c) 2024-2026 Yegor Bugayenko
 # SPDX-License-Identifier: MIT
 
-require_relative '../test__helper'
 require_relative '../../lib/factbase'
+require_relative '../test__helper'
 
 # Test.
 # Author:: Yegor Bugayenko (yegor256@gmail.com)


### PR DESCRIPTION
`(at -1 v)` silently wrapped around to the last value, while `nth` and `head`
already refuse a negative position. `at` now refuses it the same way.

Closes #831
