### PR TITLE
#829: let `matches` test every value of the property

### DIFF
--- a/lib/factbase/terms/matches.rb
+++ b/lib/factbase/terms/matches.rb
@@ -21,16 +21,16 @@ class Factbase::Matches < Factbase::TermBase
   # @param [Factbase::Fact] fact The fact
   # @param [Array<Factbase::Fact>] maps All maps available
   # @param [Factbase] fb Factbase to use for sub-queries
-  # @return [Boolean] True if the string matches the regexp, false otherwise
+  # @return [Boolean] True if any value matches the regexp, false otherwise
   def evaluate(fact, maps, fb)
     assert_args(2)
     str = _values(0, fact, maps, fb)
     return false if str.nil?
-    raise(RuntimeError, 'Exactly one string is expected') unless str.size == 1
     re = _values(1, fact, maps, fb)
     raise(RuntimeError, 'Regexp is nil') if re.nil?
     raise(RuntimeError, 'Exactly one regexp is expected') unless re.size == 1
-    str[0].to_s.match?(regexp(re[0]))
+    rx = regexp(re[0])
+    str.any? { |s| s.to_s.match?(rx) }
   end
 
   private

--- a/test/factbase/terms/test_matches_many.rb
+++ b/test/factbase/terms/test_matches_many.rb
@@ -3,8 +3,8 @@
 # SPDX-FileCopyrightText: Copyright (c) 2024-2026 Yegor Bugayenko
 # SPDX-License-Identifier: MIT
 
-require_relative '../../test__helper'
 require_relative '../../../lib/factbase'
+require_relative '../../test__helper'
 
 # Test.
 # Author:: Yegor Bugayenko (yegor256@gmail.com)

--- a/test/factbase/terms/test_matches_many.rb
+++ b/test/factbase/terms/test_matches_many.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+require_relative '../../test__helper'
+require_relative '../../../lib/factbase'
+
+# Test.
+# Author:: Yegor Bugayenko (yegor256@gmail.com)
+# Copyright:: Copyright (c) 2024-2026 Yegor Bugayenko
+# License:: MIT
+class TestMatchesMany < Factbase::Test
+  def test_matches_any_value_of_the_property
+    fb = Factbase.new
+    f = fb.insert
+    f.foo = 'aa'
+    f.foo = 'bb'
+    assert_equal(1, fb.query('(matches foo "bb")').each.to_a.size)
+  end
+end


### PR DESCRIPTION
`matches` refused a property with more than one value, while `contains`,
`starts_with` and `ends_with` all test every value and pass if any of them
matches. `matches` now behaves the same.

Closes #829
