### PR TITLE
#828: pass query params to `delete!` as well

### DIFF
--- a/lib/factbase/cached/cached_query.rb
+++ b/lib/factbase/cached/cached_query.rb
@@ -61,9 +61,9 @@ class Factbase::CachedQuery
 
   # Delete all facts that match the query.
   # @return [Integer] Total number of facts deleted
-  def delete!(fb = @fb)
+  def delete!(fb = @fb, params = {})
     @cache.clear
-    @origin.delete!(fb)
+    @origin.delete!(fb, params)
   end
 
   private

--- a/lib/factbase/impatient.rb
+++ b/lib/factbase/impatient.rb
@@ -75,9 +75,9 @@ class Factbase::Impatient
       end
     end
 
-    def delete!(fb = @fb)
+    def delete!(fb = @fb, params = {})
       impatient('delete!') do
-        @fb.query(@term, @maps).delete!(fb)
+        @fb.query(@term, @maps).delete!(fb, params)
       end
     end
 

--- a/lib/factbase/indexed/indexed_query.rb
+++ b/lib/factbase/indexed/indexed_query.rb
@@ -56,8 +56,8 @@ class Factbase::IndexedQuery
   # Delete all facts that match the query.
   # @param [Factbase] fb The factbase
   # @return [Integer] Total number of facts deleted
-  def delete!(fb = @fb)
-    @origin.delete!(fb).tap do
+  def delete!(fb = @fb, params = {})
+    @origin.delete!(fb, params).tap do
       @idx.clear
       @fresh.clear
     end

--- a/lib/factbase/logged.rb
+++ b/lib/factbase/logged.rb
@@ -187,13 +187,13 @@ class Factbase::Logged
       r
     end
 
-    def delete!(fb = @fb)
+    def delete!(fb = @fb, params = {})
       r = nil
       mono = Process.clock_gettime(Factbase::Logged::MONO)
       before = @fb.size
       tail =
         Factbase::Logged.elapsed do
-          r = @fb.query(@term, @maps).delete!(fb)
+          r = @fb.query(@term, @maps).delete!(fb, params)
         end
       raise(StandardError, ".delete! of #{@term.class} returned #{r.class}") unless r.is_a?(Integer)
       if before.zero?

--- a/lib/factbase/query.rb
+++ b/lib/factbase/query.rb
@@ -85,13 +85,16 @@ class Factbase::Query
   # same question twice (#694).
   #
   # @param [Factbase] fb The factbase to delete from
+  # @param [Hash] params Optional params accessible in the query via the "$" symbol
   # @return [Integer] Total number of facts deleted
-  def delete!(fb = @fb)
+  def delete!(fb = @fb, params = {})
     deleted = 0
-    maybe = (@term.predict(@maps, fb, Factbase::Tee.new({}, {})) || @maps).to_a.dup
+    params = params.transform_keys(&:to_s) if params.is_a?(Hash)
+    maybe = (@term.predict(@maps, fb, Factbase::Tee.new({}, params)) || @maps).to_a.dup
     @maps.delete_if do |m|
       pos = maybe.index(m)
-      d = !pos.nil? && @term.evaluate(Factbase::Accum.new(Factbase::Fact.new(m), {}, false), @maps, fb)
+      f = Factbase::Tee.new(Factbase::Fact.new(m), params)
+      d = !pos.nil? && @term.evaluate(Factbase::Accum.new(f, {}, false), @maps, fb)
       maybe.delete_at(pos) if d
       deleted += 1 if d
       d

--- a/lib/factbase/sync/sync_query.rb
+++ b/lib/factbase/sync/sync_query.rb
@@ -51,9 +51,9 @@ class Factbase::SyncQuery
   # Delete all facts that match the query.
   # @param [Factbase] fb The factbase
   # @return [Integer] Total number of facts deleted
-  def delete!(fb = @fb)
+  def delete!(fb = @fb, params = {})
     try_lock do
-      @origin.delete!(fb)
+      @origin.delete!(fb, params)
     end
   end
 

--- a/lib/factbase/tallied.rb
+++ b/lib/factbase/tallied.rb
@@ -99,8 +99,8 @@ class Factbase::Tallied
       end
     end
 
-    def delete!(fb = @fb)
-      c = @query.delete!(fb)
+    def delete!(fb = @fb, params = {})
+      c = @query.delete!(fb, params)
       @churn.append(0, c, 0)
       c
     end

--- a/test/factbase/test_impatient.rb
+++ b/test/factbase/test_impatient.rb
@@ -31,7 +31,7 @@ class TestImpatient < Factbase::Test
 
   class SlowDeleteFactbase < Factbase
     class SlowQuery < Factbase::Query
-      def delete!(fb = @fb)
+      def delete!(fb = @fb, params = {})
         sleep(0.2)
         super
       end

--- a/test/factbase/test_query_delete_params.rb
+++ b/test/factbase/test_query_delete_params.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+require_relative '../test__helper'
+require_relative '../../lib/factbase'
+
+# Test.
+# Author:: Yegor Bugayenko (yegor256@gmail.com)
+# Copyright:: Copyright (c) 2024-2026 Yegor Bugayenko
+# License:: MIT
+class TestQueryDeleteParams < Factbase::Test
+  def test_deletes_by_a_parameter
+    fb = Factbase.new
+    fb.insert.foo = 1
+    fb.insert.foo = 2
+    assert_equal(1, fb.query('(eq foo $bar)').delete!(fb, { bar: 2 }))
+    assert_equal(1, fb.size)
+  end
+end

--- a/test/factbase/test_query_delete_params.rb
+++ b/test/factbase/test_query_delete_params.rb
@@ -3,8 +3,8 @@
 # SPDX-FileCopyrightText: Copyright (c) 2024-2026 Yegor Bugayenko
 # SPDX-License-Identifier: MIT
 
-require_relative '../test__helper'
 require_relative '../../lib/factbase'
+require_relative '../test__helper'
 
 # Test.
 # Author:: Yegor Bugayenko (yegor256@gmail.com)


### PR DESCRIPTION
`delete!` took no params, so `$bar` resolved to nil, nothing matched and zero
was reported as a normal result. It now takes them like `each` and `one` do,
and the decorators pass them on.

Overlaps with #851 on `lib/factbase/tallied.rb`, so this goes up as a draft.

Closes #828
