### PR TITLE
#827: show accumulated props through the `[]` read path too

### DIFF
--- a/lib/factbase/accum.rb
+++ b/lib/factbase/accum.rb
@@ -39,20 +39,11 @@ class Factbase::Accum
       @fact.method_missing(*args) if @pass
     elsif k == '[]'
       kk = args[1].to_s
-      vv =
-        if @pass
-          []
-        else
-          @props[kk].nil? ? [] : @props[kk]
-        end
+      vv = @props[kk].nil? ? [] : @props[kk].dup
       vvv = @fact.method_missing(*args)
       vvv = [vvv] unless vvv.nil? || vvv.respond_to?(:to_a)
-      vv += vvv.to_a unless vvv.nil?
-      if vv.empty?
-        @props[kk].nil? ? nil : @props[kk]
-      else
-        vv
-      end
+      vv += vvv.to_a - vv unless vvv.nil?
+      vv.empty? ? nil : vv
     elsif @props[k].nil?
       @fact.public_send(*args)
     else

--- a/test/factbase/test_accum_views.rb
+++ b/test/factbase/test_accum_views.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+require_relative '../test__helper'
+require_relative '../../lib/factbase'
+
+# Test.
+# Author:: Yegor Bugayenko (yegor256@gmail.com)
+# Copyright:: Copyright (c) 2024-2026 Yegor Bugayenko
+# License:: MIT
+class TestAccumViews < Factbase::Test
+  def test_reads_accumulated_prop_through_brackets
+    fb = Factbase.new
+    fb.insert.foo = 1
+    fb.query('(as foo 7)').each do |f|
+      assert_equal(7, f.foo)
+      assert_includes(f['foo'], 7)
+      assert_equal(f.foo, f['foo'][0])
+    end
+  end
+end

--- a/test/factbase/test_accum_views.rb
+++ b/test/factbase/test_accum_views.rb
@@ -3,8 +3,8 @@
 # SPDX-FileCopyrightText: Copyright (c) 2024-2026 Yegor Bugayenko
 # SPDX-License-Identifier: MIT
 
-require_relative '../test__helper'
 require_relative '../../lib/factbase'
+require_relative '../test__helper'
 
 # Test.
 # Author:: Yegor Bugayenko (yegor256@gmail.com)


### PR DESCRIPTION
On a yielded fact `f.foo` returned the value written by `as` or `join`, while
`f['foo']` skipped the accumulated props and returned the stale value from the
fact. Both paths now show the same values, accumulated ones first.

Closes #827
