### PR TITLE
#839: let a light factbase iterate its facts

### DIFF
--- a/lib/factbase/light.rb
+++ b/lib/factbase/light.rb
@@ -23,6 +23,10 @@ class Factbase::Light
     @fb.insert
   end
 
+  def each(&)
+    @fb.each(&)
+  end
+
   def to_term(query)
     @fb.to_term(query)
   end

--- a/test/factbase/test_light_each.rb
+++ b/test/factbase/test_light_each.rb
@@ -3,9 +3,9 @@
 # SPDX-FileCopyrightText: Copyright (c) 2024-2026 Yegor Bugayenko
 # SPDX-License-Identifier: MIT
 
-require_relative '../test__helper'
 require_relative '../../lib/factbase'
 require_relative '../../lib/factbase/to_json'
+require_relative '../test__helper'
 
 # Test.
 # Author:: Yegor Bugayenko (yegor256@gmail.com)

--- a/test/factbase/test_light_each.rb
+++ b/test/factbase/test_light_each.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+require_relative '../test__helper'
+require_relative '../../lib/factbase'
+require_relative '../../lib/factbase/to_json'
+
+# Test.
+# Author:: Yegor Bugayenko (yegor256@gmail.com)
+# Copyright:: Copyright (c) 2024-2026 Yegor Bugayenko
+# License:: MIT
+class TestLightEach < Factbase::Test
+  def test_prints_inside_a_transaction
+    fb = Factbase.new
+    fb.insert.foo = 1
+    json = nil
+    fb.txn { |t| json = Factbase::ToJSON.new(t).json }
+    assert_includes(json, 'foo')
+  end
+end


### PR DESCRIPTION
`Light` had no `each`, so `ToJSON`, `ToXML` and `ToYAML` all raised
`NoMethodError` when a factbase was printed inside a transaction. Reading is
not what a transaction forbids, so `each` is delegated now.

Closes #839
