### PR TITLE
#835: drop the cache when facts are imported

### DIFF
--- a/lib/factbase/cached/cached_factbase.rb
+++ b/lib/factbase/cached/cached_factbase.rb
@@ -35,6 +35,13 @@ class Factbase::CachedFactbase
     Factbase::CachedFact.new(@origin.insert, @cache, fresh: true)
   end
 
+  # Import facts from a binary buffer.
+  # @param [String] data The data to import
+  def import(data)
+    @cache.clear
+    @origin.import(data)
+  end
+
   # Convert a query to a term.
   # @param [String] query The query to convert
   # @return [Factbase::Term] The term

--- a/test/factbase/cached/test_cached_import.rb
+++ b/test/factbase/cached/test_cached_import.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+require_relative '../../test__helper'
+require_relative '../../../lib/factbase'
+require_relative '../../../lib/factbase/cached/cached_factbase'
+
+# Test.
+# Author:: Yegor Bugayenko (yegor256@gmail.com)
+# Copyright:: Copyright (c) 2024-2026 Yegor Bugayenko
+# License:: MIT
+class TestCachedImport < Factbase::Test
+  def test_sees_imported_facts_after_a_query
+    src = Factbase.new
+    src.insert.foo = 42
+    fb = Factbase::CachedFactbase.new(Factbase.new)
+    assert_empty(fb.query('(exists foo)').each.to_a)
+    fb.import(src.export)
+    assert_equal(1, fb.query('(exists foo)').each.to_a.size)
+  end
+end

--- a/test/factbase/cached/test_cached_import.rb
+++ b/test/factbase/cached/test_cached_import.rb
@@ -3,9 +3,9 @@
 # SPDX-FileCopyrightText: Copyright (c) 2024-2026 Yegor Bugayenko
 # SPDX-License-Identifier: MIT
 
-require_relative '../../test__helper'
 require_relative '../../../lib/factbase'
 require_relative '../../../lib/factbase/cached/cached_factbase'
+require_relative '../../test__helper'
 
 # Test.
 # Author:: Yegor Bugayenko (yegor256@gmail.com)


### PR DESCRIPTION
`import` was delegated straight to the origin, so every query answered before
the import kept returning its stale entry and the imported facts stayed
invisible. It clears the cache now, the way `insert` and `delete!` do.

Closes #835
