### PR TITLE
#836: key the query cache on the subset of maps too

### DIFF
--- a/lib/factbase/cached/cached_factbase.rb
+++ b/lib/factbase/cached/cached_factbase.rb
@@ -49,7 +49,7 @@ class Factbase::CachedFactbase
   # @param [Array<Hash>] maps Possible maps to use
   def query(term, maps = nil)
     term = to_term(term) if term.is_a?(String)
-    Factbase::CachedQuery.new(@origin.query(term, maps), @cache, self, cacheable: !term.abstract?)
+    Factbase::CachedQuery.new(@origin.query(term, maps), @cache, self, maps:, cacheable: !term.abstract?)
   end
 
   # Run an ACID transaction.

--- a/lib/factbase/cached/cached_query.rb
+++ b/lib/factbase/cached/cached_query.rb
@@ -18,11 +18,13 @@ class Factbase::CachedQuery
   # @param [Factbase::Query] origin Original query
   # @param [Hash] cache The cache
   # @param [Factbase] fb The factbase
+  # @param [Array<Hash>] maps The subset of maps the query runs over, or NIL for all of them
   # @param [Boolean] cacheable Whether the result of the query may be cached
-  def initialize(origin, cache, fb, cacheable: true)
+  def initialize(origin, cache, fb, maps: nil, cacheable: true)
     @origin = origin
     @cache = cache
     @fb = fb
+    @maps = maps
     @cacheable = cacheable
   end
 
@@ -54,7 +56,7 @@ class Factbase::CachedQuery
   def one(fb = @fb, params = {})
     invalidate_if_dirty!
     return @origin.one(fb, params) unless @cacheable
-    key = "one: #{@origin} #{params}"
+    key = "one: #{@origin} #{params} #{scope}"
     @cache[key] = @origin.one(fb, params) if @cache[key].nil?
     @cache[key]
   end
@@ -74,9 +76,15 @@ class Factbase::CachedQuery
   # @return [Array<Factbase::Fact>] The facts
   def facts(fb, params)
     return @origin.each(fb, params).to_a unless @cacheable
-    key = "each #{@origin}"
+    key = "each #{@origin} #{params} #{scope}"
     @cache[key] = @origin.each(fb, params).to_a if @cache[key].nil?
     @cache[key]
+  end
+
+  # The part of the cache key that tells one subset of maps from another.
+  # @return [String] The scope of the query
+  def scope
+    @maps.nil? ? 'all' : @maps.object_id.to_s
   end
 
   # Clear cache if it was marked dirty by a fresh fact insertion.

--- a/test/factbase/cached/test_cached_scope.rb
+++ b/test/factbase/cached/test_cached_scope.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+require_relative '../../test__helper'
+require_relative '../../../lib/factbase'
+require_relative '../../../lib/factbase/cached/cached_factbase'
+
+# Test.
+# Author:: Yegor Bugayenko (yegor256@gmail.com)
+# Copyright:: Copyright (c) 2024-2026 Yegor Bugayenko
+# License:: MIT
+class TestCachedScope < Factbase::Test
+  def test_does_not_share_the_answer_of_a_subset_query
+    fb = Factbase::CachedFactbase.new(Factbase.new)
+    fb.insert.foo = 1
+    fb.insert.foo = 2
+    sub = fb.each.to_a[0..0]
+    assert_equal(1, fb.query('(exists foo)', sub).each.to_a.size)
+    assert_equal(2, fb.query('(exists foo)').each.to_a.size)
+  end
+end

--- a/test/factbase/cached/test_cached_scope.rb
+++ b/test/factbase/cached/test_cached_scope.rb
@@ -16,8 +16,7 @@ class TestCachedScope < Factbase::Test
     fb = Factbase::CachedFactbase.new(Factbase.new)
     fb.insert.foo = 1
     fb.insert.foo = 2
-    sub = fb.each.to_a[0..0]
-    assert_equal(1, fb.query('(exists foo)', sub).each.to_a.size)
+    assert_equal(1, fb.query('(exists foo)', fb.each.to_a[0..0]).each.to_a.size)
     assert_equal(2, fb.query('(exists foo)').each.to_a.size)
   end
 end

--- a/test/factbase/cached/test_cached_scope.rb
+++ b/test/factbase/cached/test_cached_scope.rb
@@ -3,9 +3,9 @@
 # SPDX-FileCopyrightText: Copyright (c) 2024-2026 Yegor Bugayenko
 # SPDX-License-Identifier: MIT
 
-require_relative '../../test__helper'
 require_relative '../../../lib/factbase'
 require_relative '../../../lib/factbase/cached/cached_factbase'
+require_relative '../../test__helper'
 
 # Test.
 # Author:: Yegor Bugayenko (yegor256@gmail.com)


### PR DESCRIPTION
The cache key was the query text alone, so a query over a subset of maps and
the same query over the whole factbase shared one answer, and whichever ran
first won. The key now carries the subset and the params as well.

Overlaps with #854 and #857 on the cached files, so this goes up as a draft.

Closes #836
