### PR TITLE
#834: keep the churn when a transaction ends with a thrown commit

### DIFF
--- a/lib/factbase/tallied.rb
+++ b/lib/factbase/tallied.rb
@@ -39,8 +39,13 @@ class Factbase::Tallied
     commit = false
     @fb.txn do |fbt|
       catch(:rollback) do
-        yield(Factbase::Tallied.new(fbt, @churn))
+        thrown = true
+        catch(:commit) do
+          yield(Factbase::Tallied.new(fbt, @churn))
+          thrown = false
+        end
         commit = true
+        throw(:commit) if thrown
       end
     rescue Factbase::Rollback => e
       @churn = before

--- a/test/factbase/test_tallied_commit.rb
+++ b/test/factbase/test_tallied_commit.rb
@@ -3,9 +3,9 @@
 # SPDX-FileCopyrightText: Copyright (c) 2024-2026 Yegor Bugayenko
 # SPDX-License-Identifier: MIT
 
-require_relative '../test__helper'
 require_relative '../../lib/factbase'
 require_relative '../../lib/factbase/tallied'
+require_relative '../test__helper'
 
 # Test.
 # Author:: Yegor Bugayenko (yegor256@gmail.com)

--- a/test/factbase/test_tallied_commit.rb
+++ b/test/factbase/test_tallied_commit.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+require_relative '../test__helper'
+require_relative '../../lib/factbase'
+require_relative '../../lib/factbase/tallied'
+
+# Test.
+# Author:: Yegor Bugayenko (yegor256@gmail.com)
+# Copyright:: Copyright (c) 2024-2026 Yegor Bugayenko
+# License:: MIT
+class TestTalliedCommit < Factbase::Test
+  def test_counts_facts_of_a_thrown_commit
+    fb = Factbase::Tallied.new(Factbase.new)
+    fb.txn do |t|
+      t.insert.foo = 1
+      throw :commit
+    end
+    assert_equal(1, fb.size)
+    assert_equal(1, fb.churn.inserted)
+  end
+end

--- a/test/factbase/test_tallied_commit.rb
+++ b/test/factbase/test_tallied_commit.rb
@@ -16,7 +16,7 @@ class TestTalliedCommit < Factbase::Test
     fb = Factbase::Tallied.new(Factbase.new)
     fb.txn do |t|
       t.insert.foo = 1
-      throw :commit
+      throw(:commit)
     end
     assert_equal(1, fb.size)
     assert_equal(1, fb.churn.inserted)


### PR DESCRIPTION
`throw :commit` unwound past the `catch(:rollback)` without setting the commit
flag, so the ensure branch threw the churn away while the facts were written.
The throw is caught and passed on now, and the churn survives it.

Overlaps with #851 on `lib/factbase/tallied.rb`, so this goes up as a draft.

Closes #834
