### PR TITLE
#838: pick the facts first, delete them afterwards

### DIFF
--- a/lib/factbase/query.rb
+++ b/lib/factbase/query.rb
@@ -93,12 +93,13 @@ class Factbase::Query
   def delete!(fb = @fb)
     maybe = (@term.predict(@maps, fb, Factbase::Tee.new({}, {})) || @maps).to_a.dup
     doomed = {}.compare_by_identity
-    @maps.each do |m|
+    @maps.delete_if do |m|
       pos = maybe.index(m)
-      next if pos.nil?
-      next unless @term.evaluate(Factbase::Accum.new(Factbase::Fact.new(m), {}, false), @maps, fb)
-      maybe.delete_at(pos)
-      doomed[m] = true
+      unless pos.nil? || !@term.evaluate(Factbase::Accum.new(Factbase::Fact.new(m), {}, false), @maps, fb)
+        maybe.delete_at(pos)
+        doomed[m] = true
+      end
+      false
     end
     @maps.delete_if { |m| doomed.key?(m) }
     doomed.size

--- a/lib/factbase/query.rb
+++ b/lib/factbase/query.rb
@@ -78,6 +78,10 @@ class Factbase::Query
 
   # Delete all facts that match the query.
   #
+  # The facts are picked first and removed afterwards, so a `delete!` that is
+  # interrupted in the middle, by a timeout for example, leaves the factbase
+  # untouched instead of destroying the part it has already visited.
+  #
   # The term is asked about every fact exactly once, and it is asked
   # through the same accumulator that {#each} uses, so a term that writes,
   # like `as`, writes into a throw-away copy and leaves the surviving facts
@@ -87,15 +91,16 @@ class Factbase::Query
   # @param [Factbase] fb The factbase to delete from
   # @return [Integer] Total number of facts deleted
   def delete!(fb = @fb)
-    deleted = 0
     maybe = (@term.predict(@maps, fb, Factbase::Tee.new({}, {})) || @maps).to_a.dup
-    @maps.delete_if do |m|
+    doomed = {}.compare_by_identity
+    @maps.each do |m|
       pos = maybe.index(m)
-      d = !pos.nil? && @term.evaluate(Factbase::Accum.new(Factbase::Fact.new(m), {}, false), @maps, fb)
-      maybe.delete_at(pos) if d
-      deleted += 1 if d
-      d
+      next if pos.nil?
+      next unless @term.evaluate(Factbase::Accum.new(Factbase::Fact.new(m), {}, false), @maps, fb)
+      maybe.delete_at(pos)
+      doomed[m] = true
     end
-    deleted
+    @maps.delete_if { |m| doomed.key?(m) }
+    doomed.size
   end
 end

--- a/test/factbase/test_query_delete_atomic.rb
+++ b/test/factbase/test_query_delete_atomic.rb
@@ -19,11 +19,10 @@ class TestQueryDeleteAtomic < Factbase::Test
       f.foo = i
       f.bar = "x#{i}"
     end
-    before = fb.size
     imp = Factbase::Impatient.new(fb, timeout: 0.05)
     assert_raises(StandardError) do
       imp.query('(and (exists foo) (matches bar "^x[0-9]*$"))').delete!
     end
-    assert_equal(before, fb.size)
+    assert_equal(20_000, fb.size)
   end
 end

--- a/test/factbase/test_query_delete_atomic.rb
+++ b/test/factbase/test_query_delete_atomic.rb
@@ -3,9 +3,9 @@
 # SPDX-FileCopyrightText: Copyright (c) 2024-2026 Yegor Bugayenko
 # SPDX-License-Identifier: MIT
 
-require_relative '../test__helper'
 require_relative '../../lib/factbase'
 require_relative '../../lib/factbase/impatient'
+require_relative '../test__helper'
 
 # Test.
 # Author:: Yegor Bugayenko (yegor256@gmail.com)

--- a/test/factbase/test_query_delete_atomic.rb
+++ b/test/factbase/test_query_delete_atomic.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+require_relative '../test__helper'
+require_relative '../../lib/factbase'
+require_relative '../../lib/factbase/impatient'
+
+# Test.
+# Author:: Yegor Bugayenko (yegor256@gmail.com)
+# Copyright:: Copyright (c) 2024-2026 Yegor Bugayenko
+# License:: MIT
+class TestQueryDeleteAtomic < Factbase::Test
+  def test_deletes_nothing_when_it_times_out
+    fb = Factbase.new
+    20_000.times do |i|
+      f = fb.insert
+      f.foo = i
+      f.bar = "x#{i}"
+    end
+    before = fb.size
+    imp = Factbase::Impatient.new(fb, timeout: 0.05)
+    assert_raises(StandardError) do
+      imp.query('(and (exists foo) (matches bar "^x[0-9]*$"))').delete!
+    end
+    assert_equal(before, fb.size)
+  end
+end


### PR DESCRIPTION
A `delete!` interrupted by the `Impatient` timeout left the factbase half
deleted, with the count lost, so the caller could not tell what had happened.
The facts are picked first now and removed in one pass at the end, so an
interrupted call leaves the factbase as it was.

Overlaps with #854 on `lib/factbase/query.rb`, so this goes up as a draft.

Closes #838
