### PR TITLE
#837: make the decorated queries enumerable too

### DIFF
--- a/lib/factbase/impatient.rb
+++ b/lib/factbase/impatient.rb
@@ -44,6 +44,8 @@ class Factbase::Impatient
   #
   # This is an internal class, it is not supposed to be instantiated directly.
   class Query
+    include Enumerable
+
     def initialize(term, maps, timeout, fb)
       @term = term
       @maps = maps

--- a/lib/factbase/logged.rb
+++ b/lib/factbase/logged.rb
@@ -134,6 +134,8 @@ class Factbase::Logged
   #
   # This is an internal class, it is not supposed to be instantiated directly.
   class Query
+    include Enumerable
+
     def initialize(term, maps, tube, fb)
       @term = term
       @maps = maps

--- a/lib/factbase/tallied.rb
+++ b/lib/factbase/tallied.rb
@@ -78,6 +78,8 @@ class Factbase::Tallied
   #
   # This is an internal class, it is not supposed to be instantiated directly.
   class Query
+    include Enumerable
+
     def initialize(query, churn, fb)
       @query = query
       @churn = churn

--- a/test/factbase/test_decorated_query_enumerable.rb
+++ b/test/factbase/test_decorated_query_enumerable.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+require 'loog'
+require_relative '../../lib/factbase'
+require_relative '../../lib/factbase/impatient'
+require_relative '../../lib/factbase/logged'
+require_relative '../../lib/factbase/tallied'
+require_relative '../test__helper'
+
+# Test.
+# Author:: Yegor Bugayenko (yegor256@gmail.com)
+# Copyright:: Copyright (c) 2024-2026 Yegor Bugayenko
+# License:: MIT
+class TestDecoratedQueryEnumerable < Factbase::Test
+  def test_maps_a_decorated_query
+    [
+      Factbase::Logged.new(Factbase.new, Loog::NULL),
+      Factbase::Impatient.new(Factbase.new),
+      Factbase::Tallied.new(Factbase.new)
+    ].each do |fb|
+      fb.insert.foo = 1
+      fb.insert.foo = 2
+      q = fb.query('(exists foo)')
+      assert_equal(2, q.to_a.size)
+      assert_equal([1, 2], q.map(&:foo))
+    end
+  end
+end


### PR DESCRIPTION
The queries of `Logged`, `Impatient` and `Tallied` defined `each` but included
nothing, so `to_a`, `map` and the rest raised `NoMethodError` on the outermost
wrappers of the stack. They include `Enumerable` now, like the other four.

Overlaps with #851, #854 and #859 on those three files, so this goes up as a draft.

Closes #837
