### PR TITLE
#840: log the writes made to a fact that came from a query

### DIFF
--- a/lib/factbase/logged.rb
+++ b/lib/factbase/logged.rb
@@ -153,7 +153,10 @@ class Factbase::Logged
       qry = @fb.query(@term, @maps)
       tail =
         Factbase::Logged.elapsed do
-          r = qry.each(fb, params, &)
+          r =
+            qry.each(fb, params) do |f|
+              yield(Factbase::Logged::Fact.new(f, tube: @tube))
+            end
         end
       unless r.is_a?(Integer)
         raise(StandardError, ".query(#{@termtext.inspect}).each() of #{qry.class} returned #{r.class}")

--- a/test/factbase/test_logged_writes.rb
+++ b/test/factbase/test_logged_writes.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+require 'loog'
+require_relative '../../lib/factbase'
+require_relative '../../lib/factbase/logged'
+require_relative '../test__helper'
+
+# Test.
+# Author:: Yegor Bugayenko (yegor256@gmail.com)
+# Copyright:: Copyright (c) 2024-2026 Yegor Bugayenko
+# License:: MIT
+class TestLoggedWrites < Factbase::Test
+  def test_logs_a_write_through_a_query
+    log = Loog::Buffer.new
+    fb = Factbase::Logged.new(Factbase.new, log)
+    fb.insert.foo = 1
+    fb.query('(exists foo)').each { |f| f.bar = 7 }
+    assert_includes(log.to_s, "Set 'bar' to 7")
+  end
+end


### PR DESCRIPTION
`Logged::Query#each` passed the block to the inner query untouched, so a
property written on a fact that came out of a query never reached the log.
It wraps what it yields now, the way `Tallied` and `Inv` do.

Overlaps with #854 and #861 on `lib/factbase/logged.rb`, so this goes up as a draft.

Closes #840
