### PR TITLE
#830: explain a `defn` body that is not valid Ruby

### DIFF
--- a/lib/factbase/terms/defn.rb
+++ b/lib/factbase/terms/defn.rb
@@ -30,12 +30,16 @@ class Factbase::Defn < Factbase::TermBase
     raise(ArgumentError, "Term '#{fn}' is already defined") if Factbase::Term.private_method_defined?(fn, false)
     raise(ArgumentError, "Term '#{fn}' is already defined") if Factbase::Term::TERMS.key?(fn)
     raise(ArgumentError, "The '#{fn}' is a bad name for a term") unless fn.match?(/^[a-z_]+$/)
-    # rubocop:disable Security/Eval
-    eval(
-      "class Factbase::Term\nprivate\ndef #{fn}(fact, maps, fb)\n#{@operands[1]}\nend\nend",
-      binding, __FILE__, __LINE__ - 1
-    )
-    # rubocop:enable Security/Eval
+    begin
+      # rubocop:disable Security/Eval
+      eval(
+        "class Factbase::Term\nprivate\ndef #{fn}(fact, maps, fb)\n#{@operands[1]}\nend\nend",
+        binding, __FILE__, __LINE__ - 1
+      )
+      # rubocop:enable Security/Eval
+    rescue SyntaxError => e
+      raise(ArgumentError, "Cannot define the term '#{fn}', its body is not valid Ruby: #{e.message}")
+    end
     true
   end
 end

--- a/test/factbase/terms/test_defn_syntax.rb
+++ b/test/factbase/terms/test_defn_syntax.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+require_relative '../../../lib/factbase'
+require_relative '../../test__helper'
+
+# Test.
+# Author:: Yegor Bugayenko (yegor256@gmail.com)
+# Copyright:: Copyright (c) 2024-2026 Yegor Bugayenko
+# License:: MIT
+class TestDefnSyntax < Factbase::Test
+  def test_explains_a_body_that_is_not_ruby
+    fb = Factbase.new
+    fb.insert.foo = 1
+    e =
+      assert_raises(StandardError) do
+        fb.query('(defn brk "1 +")').each.to_a
+      end
+    assert_includes(e.message, "Cannot define the term 'brk'", e.message)
+  end
+end


### PR DESCRIPTION
A malformed `defn` body raised `SyntaxError`, which is a `ScriptError`, so no
`rescue StandardError` in the gem or in the caller could catch it. It is turned
into an `ArgumentError` naming the term now.

Closes #830
