### PR TITLE
#826: remember which quote opened a string literal

### DIFF
--- a/lib/factbase/syntax.rb
+++ b/lib/factbase/syntax.rb
@@ -100,20 +100,22 @@ class Factbase::Syntax
     acc = ''
     quotes = ['\'', '"']
     spaces = [' ', ')', "\n", "\t", "\r"]
-    string = false
+    opener = nil
     comment = false
     @query.to_s.chars.each do |c|
-      comment = true if !string && c == '#'
+      comment = true if opener.nil? && c == '#'
       comment = false if comment && c == "\n"
       next if comment
       if quotes.include?(c)
-        if string && acc[-1] == '\\'
+        if !opener.nil? && acc[-1] == '\\'
           acc = acc[0..-2]
-        else
-          string = !string
+        elsif opener.nil?
+          opener = c
+        elsif opener == c
+          opener = nil
         end
       end
-      if string
+      if opener
         acc += c
         next
       end
@@ -132,7 +134,7 @@ class Factbase::Syntax
         acc += c
       end
     end
-    raise(StandardError, 'String not closed') if string
+    raise(StandardError, 'String not closed') unless opener.nil?
     list.map do |t|
       if t.is_a?(Symbol)
         t

--- a/test/factbase/test_syntax_quotes.rb
+++ b/test/factbase/test_syntax_quotes.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+require_relative '../../lib/factbase'
+require_relative '../test__helper'
+
+# Test.
+# Author:: Yegor Bugayenko (yegor256@gmail.com)
+# Copyright:: Copyright (c) 2024-2026 Yegor Bugayenko
+# License:: MIT
+class TestSyntaxQuotes < Factbase::Test
+  def test_keeps_a_quote_of_the_other_kind_inside_a_literal
+    fb = Factbase.new
+    fb.insert.foo = "Jeff's"
+    assert_equal(1, fb.query('(eq foo "Jeff\'s")').each.to_a.size)
+  end
+
+  def test_does_not_split_a_literal_with_two_intruding_quotes
+    fb = Factbase.new
+    fb.insert.foo = 'a" "b'
+    assert_equal(1, fb.query(%q{(eq foo 'a" "b')}).each.to_a.size)
+  end
+end


### PR DESCRIPTION
The tokenizer kept one boolean for "inside a string", so a quote of the other
kind closed the literal: `(eq foo "Jeff's")` died with "String not closed" and
an even number of intruding quotes silently cut the literal into two tokens.
It remembers the opening quote now and only that one closes the literal.

Overlaps with open PRs #843 and #813 on `lib/factbase/syntax.rb`, so this goes up as a draft.

Closes #826
