### PR TITLE
#844: index a repeated value once

### DIFF
--- a/lib/factbase/indexed/indexed_eq.rb
+++ b/lib/factbase/indexed/indexed_eq.rb
@@ -38,7 +38,7 @@ class Factbase::IndexedEq
   def _feed(facts, entry, operand)
     return unless entry[:count] < facts.size
     facts[entry[:count]..].each do |m|
-      m[operand]&.each do |v|
+      m[operand]&.uniq&.each do |v|
         entry[:facts][v] ||= []
         entry[:facts][v] << m
       end

--- a/test/factbase/indexed/test_indexed_eq.rb
+++ b/test/factbase/indexed/test_indexed_eq.rb
@@ -2,6 +2,7 @@
 
 require_relative '../../../lib/factbase'
 require_relative '../../../lib/factbase/indexed/indexed_eq'
+require_relative '../../../lib/factbase/indexed/indexed_factbase'
 require_relative '../../../lib/factbase/indexed/indexed_term'
 require_relative '../../../lib/factbase/lazy_taped'
 require_relative '../../../lib/factbase/taped'
@@ -66,5 +67,14 @@ class TestIndexedEq < Factbase::Test
       n = term.predict(c[:input], nil, {})
       assert_kind_of(c[:expected], n, "Expect #{c[:expected]}, but got #{n.class} for input #{c[:input].class}")
     end
+  end
+
+  def test_yields_a_fact_with_repeated_values_once
+    maps = [{ 'a' => [2, 2] }, { 'a' => [1] }]
+    assert_equal(
+      Factbase.new(maps.map(&:dup)).query('(eq a 2)').each.to_a.size,
+      Factbase::IndexedFactbase.new(Factbase.new(maps.map(&:dup))).query('(eq a 2)').each.to_a.size,
+      'a fact that stores the same value twice must be returned once, as it is without the index'
+    )
   end
 end


### PR DESCRIPTION
Fixes #844.

A fact that stores the same value twice was appended to that value's bucket twice, so `(eq a 2)` over `{ 'a' => [2, 2] }` returned it twice through the index while a plain `Factbase` returned it once. The `uniq!` in `predict` only ran when the parameter resolved to several keys, so the scalar case kept the duplicate.

The fix is in `_feed`: a fact enters each bucket once, no matter how often the value repeats. That keeps the deduplication where it costs nothing, instead of on every read of the bucket, and the multi-key `uniq!` stays as it is, since there a fact can legitimately sit in two different buckets.
