### PR TITLE
#845: keep the insertion order in gte and lte

### DIFF
--- a/lib/factbase/indexed/indexed_gte.rb
+++ b/lib/factbase/indexed/indexed_gte.rb
@@ -33,9 +33,9 @@ class Factbase::IndexedGte
 
   def _feed(facts, entry, prop)
     return unless entry[:count] < facts.size
-    facts[entry[:count]..].each do |fact|
+    facts[entry[:count]..].each_with_index do |fact, i|
       fact[prop]&.each do |v|
-        entry[:facts] << [v, fact]
+        entry[:facts] << [v, fact, entry[:count] + i]
       end
     end
     entry[:facts].sort_by! { |pair| pair[0] }
@@ -52,7 +52,7 @@ class Factbase::IndexedGte
   def _search(entry, target)
     idx = entry[:facts].bsearch_index { |v, _| v >= target }
     return [] if idx.nil?
-    facts = entry[:facts][idx..].map { |_, f| f }
+    facts = entry[:facts][idx..].sort_by { |pair| pair[2] }.map { |pair| pair[1] }
     facts.uniq!(&:object_id)
     facts
   end

--- a/lib/factbase/indexed/indexed_lte.rb
+++ b/lib/factbase/indexed/indexed_lte.rb
@@ -33,9 +33,9 @@ class Factbase::IndexedLte
 
   def _feed(facts, entry, prop)
     return unless entry[:count] < facts.size
-    facts[entry[:count]..].each do |fact|
+    facts[entry[:count]..].each_with_index do |fact, i|
       fact[prop]&.each do |v|
-        entry[:facts] << [v, fact]
+        entry[:facts] << [v, fact, entry[:count] + i]
       end
     end
     entry[:facts].sort_by! { |pair| pair[0] }
@@ -52,7 +52,7 @@ class Factbase::IndexedLte
   def _search(entry, target)
     idx = entry[:facts].bsearch_index { |v, _| v > target }
     res = idx.nil? ? entry[:facts] : entry[:facts][0...idx]
-    facts = res.map { |_, f| f }
+    facts = res.sort_by { |pair| pair[2] }.map { |pair| pair[1] }
     facts.uniq!(&:object_id)
     facts
   end

--- a/test/factbase/indexed/test_indexed_gte.rb
+++ b/test/factbase/indexed/test_indexed_gte.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require_relative '../../../lib/factbase'
+require_relative '../../../lib/factbase/indexed/indexed_factbase'
+require_relative '../../../lib/factbase/indexed/indexed_gte'
+require_relative '../../../lib/factbase/indexed/indexed_term'
+require_relative '../../../lib/factbase/taped'
+require_relative '../../../lib/factbase/term'
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+require_relative '../../test__helper'
+
+# Indexed term 'gte' test.
+# Author:: Yegor Bugayenko (yegor256@gmail.com)
+# Copyright:: Copyright (c) 2024-2026 Yegor Bugayenko
+# License:: MIT
+class TestIndexedGte < Factbase::Test
+  def test_keeps_the_order_the_facts_were_inserted_in
+    term = Factbase::Term.new(:gte, [:num, 2])
+    term.redress!(Factbase::IndexedTerm, idx: {})
+    maps = Factbase::Taped.new(
+      [
+        { 'num' => [5], 'tag' => ['t0'] },
+        { 'num' => [1], 'tag' => ['t1'] },
+        { 'num' => [3], 'tag' => ['t2'] },
+        { 'num' => [2], 'tag' => ['t3'] }
+      ]
+    )
+    assert_equal(%w[t0 t2 t3], term.predict(maps, Factbase.new, {}).to_a.map { |m| m['tag'].first })
+  end
+
+  def test_orders_as_a_plain_factbase_does
+    maps = [{ 'a' => [3] }, { 'a' => [0] }, { 'a' => [2] }, { 'a' => [1] }]
+    assert_equal(
+      Factbase.new(maps.map(&:dup)).query('(gte a 1)').each.to_a.map { |f| f['a'].first },
+      Factbase::IndexedFactbase.new(
+        Factbase.new(maps.map(&:dup))
+      ).query('(gte a 1)').each.to_a.map { |f| f['a'].first },
+      'the index must not reorder the facts of a range query'
+    )
+  end
+end

--- a/test/factbase/indexed/test_indexed_lte.rb
+++ b/test/factbase/indexed/test_indexed_lte.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require_relative '../../../lib/factbase'
+require_relative '../../../lib/factbase/indexed/indexed_factbase'
+require_relative '../../../lib/factbase/indexed/indexed_lte'
+require_relative '../../../lib/factbase/indexed/indexed_term'
+require_relative '../../../lib/factbase/taped'
+require_relative '../../../lib/factbase/term'
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+require_relative '../../test__helper'
+
+# Indexed term 'lte' test.
+# Author:: Yegor Bugayenko (yegor256@gmail.com)
+# Copyright:: Copyright (c) 2024-2026 Yegor Bugayenko
+# License:: MIT
+class TestIndexedLte < Factbase::Test
+  def test_keeps_the_order_the_facts_were_inserted_in
+    term = Factbase::Term.new(:lte, [:num, 3])
+    term.redress!(Factbase::IndexedTerm, idx: {})
+    maps = Factbase::Taped.new(
+      [
+        { 'num' => [5], 'tag' => ['t0'] },
+        { 'num' => [1], 'tag' => ['t1'] },
+        { 'num' => [3], 'tag' => ['t2'] },
+        { 'num' => [2], 'tag' => ['t3'] }
+      ]
+    )
+    assert_equal(%w[t1 t2 t3], term.predict(maps, Factbase.new, {}).to_a.map { |m| m['tag'].first })
+  end
+
+  def test_orders_as_a_plain_factbase_does
+    maps = [{ 'a' => [3] }, { 'a' => [0] }, { 'a' => [2] }, { 'a' => [1] }]
+    assert_equal(
+      Factbase.new(maps.map(&:dup)).query('(lte a 1)').each.to_a.map { |f| f['a'].first },
+      Factbase::IndexedFactbase.new(
+        Factbase.new(maps.map(&:dup))
+      ).query('(lte a 1)').each.to_a.map { |f| f['a'].first },
+      'the index must not reorder the facts of a range query'
+    )
+  end
+end


### PR DESCRIPTION
Fixes #845.

`IndexedGte` and `IndexedLte` handed back the facts in the order of the sorted index, so turning the index on changed the answer of a query: `(gte a 1)` over `[3, 0, 2]` gave `[2, 3]` instead of the `[3, 2]` a plain `Factbase` returns.

`IndexedGt` and `IndexedLt` already keep the source position in the index entry and sort by it before returning. Both siblings now do the same, so all four range operators agree with a plain `Factbase`.

There were no test files for the two of them; they exist now, each with the order test its `gt`/`lt` sibling has and a direct comparison against a plain `Factbase` over the same maps. All four assertions fail on master.
