### PR TITLE
#847: cache the negation per set of params

### DIFF
--- a/lib/factbase/indexed/indexed_not.rb
+++ b/lib/factbase/indexed/indexed_not.rb
@@ -12,7 +12,7 @@ class Factbase::IndexedNot
 
   def predict(maps, fb, params)
     sub = @term.operands.first
-    key = [maps.object_id, sub, @term.op]
+    key = [maps.object_id, sub, @term.op, snapshot(params)]
     @idx[key] ||= { facts: nil, count: 0, yes_set: nil }
     entry = @idx[key]
     _feed(maps.to_a, entry) do
@@ -23,6 +23,13 @@ class Factbase::IndexedNot
   end
 
   private
+
+  def snapshot(params)
+    return params.to_a.sort_by { |pair| pair[0].to_s } if params.is_a?(Hash)
+    return params unless params.respond_to?(:all_properties)
+    keys = params.all_properties.sort
+    keys.map { |k| [k, params["$#{k}"]] }
+  end
 
   def _feed(facts, entry)
     return unless entry[:count] < facts.size

--- a/test/factbase/indexed/test_indexed_not.rb
+++ b/test/factbase/indexed/test_indexed_not.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative '../../../lib/factbase'
+require_relative '../../../lib/factbase/indexed/indexed_factbase'
 require_relative '../../../lib/factbase/indexed/indexed_not'
 require_relative '../../../lib/factbase/indexed/indexed_term'
 require_relative '../../../lib/factbase/lazy_taped'
@@ -45,6 +46,20 @@ class TestIndexedNot < Factbase::Test
       n = term.predict(c[:input], nil, {})
       assert_kind_of(c[:expected], n, "Expect #{c[:expected]}, but got #{n.class}")
     end
+  end
+
+  def test_answers_each_set_of_params_on_its_own
+    origin = Factbase.new
+    origin.insert.foo = 1
+    origin.insert.foo = 2
+    fb = Factbase::IndexedFactbase.new(origin)
+    query = fb.query('(not (eq foo $x))')
+    assert_equal([2], query.each(fb, { 'x' => 1 }).to_a.map { |f| f['foo'].first })
+    assert_equal(
+      [1], query.each(fb, { 'x' => 2 }).to_a.map { |f| f['foo'].first },
+      'the prediction of the first parameter must not be reused for the second one'
+    )
+    assert_equal([2], query.each(fb, { 'x' => 1 }).to_a.map { |f| f['foo'].first })
   end
 
   private


### PR DESCRIPTION
Fixes #847.

`IndexedNot` keyed its prediction on the maps, the sub-term and the operator, but not on the parameters, so `(not (eq foo $x))` answered every later call with the set it computed for the first `$x`. In the reproduction from the issue the second call returned nothing instead of `[1]`.

The key now carries a snapshot of the parameters. At query time they arrive as a `Factbase::Tee` rather than a `Hash` (its `to_a` is delegated to the wrapped fact, which is empty, so the naive `params.to_a` snapshot is the same for every call), so `snapshot` reads them through `all_properties` and `$`-lookup, and still handles a plain `Hash`, which is what the unit tests pass.

The test runs the reproduction, then repeats the first parameter to show the cache is still used and still correct. It fails on master.
