### PR TITLE
#846: write a new fact while holding the monitor

### DIFF
--- a/lib/factbase/sync/sync_fact.rb
+++ b/lib/factbase/sync/sync_fact.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+require 'others'
+require_relative '../../factbase'
+
+# A single fact, which is only touched while holding the monitor.
+#
+# Author:: Yegor Bugayenko (yegor256@gmail.com)
+# Copyright:: Copyright (c) 2024-2026 Yegor Bugayenko
+# License:: MIT
+class Factbase::SyncFact
+  # Ctor.
+  # @param [Factbase::Fact] origin The original fact
+  # @param [Monitor] monitor The monitor to hold while reading or writing
+  def initialize(origin, monitor)
+    @origin = origin
+    @monitor = monitor
+  end
+
+  def to_s
+    @monitor.synchronize { @origin.to_s }
+  end
+
+  others do |*args|
+    @monitor.synchronize { @origin.__send__(*args) }
+  end
+end

--- a/lib/factbase/sync/sync_factbase.rb
+++ b/lib/factbase/sync/sync_factbase.rb
@@ -27,7 +27,8 @@ class Factbase::SyncFactbase
   # @return [Factbase::Fact] The fact just inserted
   def insert
     try_lock do
-      @origin.insert
+      require_relative('sync_fact')
+      Factbase::SyncFact.new(@origin.insert, @monitor)
     end
   end
 

--- a/test/factbase/sync/test_sync_fact.rb
+++ b/test/factbase/sync/test_sync_fact.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require 'monitor'
+require_relative '../../../lib/factbase'
+require_relative '../../../lib/factbase/sync/sync_fact'
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+require_relative '../../test__helper'
+
+# Sync fact test.
+# Author:: Yegor Bugayenko (yegor256@gmail.com)
+# Copyright:: Copyright (c) 2024-2026 Yegor Bugayenko
+# License:: MIT
+class TestSyncFact < Factbase::Test
+  def test_reads_and_writes_through_the_origin
+    fb = Factbase.new
+    fact = Factbase::SyncFact.new(fb.insert, Monitor.new)
+    fact.foo = 42
+    assert_equal([42], fact['foo'])
+    assert_equal([42], fb.query('(exists foo)').each.to_a.first['foo'])
+  end
+
+  def test_prints_what_the_origin_prints
+    origin = Factbase.new.insert
+    origin.foo = 42
+    assert_equal(origin.to_s, Factbase::SyncFact.new(origin, Monitor.new).to_s)
+  end
+
+  def test_waits_for_the_monitor_to_be_free
+    monitor = Monitor.new
+    fact = Factbase::SyncFact.new(Factbase.new.insert, monitor)
+    done = Queue.new
+    writer = nil
+    monitor.synchronize do
+      writer =
+        Thread.new do
+          fact.foo = 42
+          done << :written
+        end
+      sleep(0.2)
+      assert_empty(done, 'the write must not happen while another thread holds the monitor')
+    end
+    writer.join
+    assert_equal([42], fact['foo'])
+  end
+end

--- a/test/factbase/sync/test_sync_factbase.rb
+++ b/test/factbase/sync/test_sync_factbase.rb
@@ -3,6 +3,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2024-2026 Yegor Bugayenko
 # SPDX-License-Identifier: MIT
 
+require 'monitor'
 require 'threads'
 require_relative '../../../lib/factbase'
 require_relative '../../../lib/factbase/sync/sync_factbase'
@@ -78,5 +79,24 @@ class TestSyncFactbase < Factbase::Test
       assert_equal(1, fs.size)
       assert_equal(t, fs.first['foo'].size)
     end
+  end
+
+  def test_writes_to_a_new_fact_under_the_monitor
+    monitor = Monitor.new
+    fb = Factbase::SyncFactbase.new(Factbase.new, monitor)
+    fact = fb.insert
+    done = Queue.new
+    writer = nil
+    monitor.synchronize do
+      writer =
+        Thread.new do
+          fact.foo = 42
+          done << :written
+        end
+      sleep(0.2)
+      assert_empty(done, 'a property of a new fact must not be written while another thread holds the monitor')
+    end
+    writer.join
+    assert_equal(42, fb.query('(exists foo)').each.to_a.first['foo'].first)
   end
 end


### PR DESCRIPTION
Fixes #846.

`SyncFactbase#insert` held the monitor only while the empty fact was allocated and then handed back the raw fact of the origin. Everything the caller wrote afterwards, which is where the fact actually gets its content, happened with no synchronization at all: two writers could mutate the same fact at once, and a reader could walk it mid-write.

`insert` now returns a `Factbase::SyncFact`, a thin wrapper that takes the same monitor around every call it forwards, so the writes that follow an insert are as synchronized as the insert itself. That is the first of the two options in the issue; the second one (insertion and population as a single operation) would change the signature of `insert` for every caller.

Note that this makes each write atomic, not the whole population of a fact: a reader can still see a fact that has `a` but not yet `b`. Making the sequence atomic needs a block form of `insert`, which is a larger change, and I did not want to smuggle it in here.

The test in `test_sync_factbase.rb` holds the monitor in the main thread and shows that a write from another thread does not go through until the monitor is released; on master it goes through immediately. `test_sync_fact.rb` covers the wrapper itself.
